### PR TITLE
Ui updates for sprint 2

### DIFF
--- a/content/locationTypes.json
+++ b/content/locationTypes.json
@@ -1,10 +1,46 @@
 [{
-    "label": "Type 1",
-    "value": "a"
+    "label": "Airport",
+    "value": "airport"
 },{
-    "label": "Type 2",
-    "value": "b"
+    "label": "Bus Station",
+    "value": "busStation"
 },{
-    "label": "Type 3",
-    "value": "c"
+    "label": "Church",
+    "value": "church"
+},{
+    "label": "Home",
+    "value": "home"
+},{
+    "label": "Hospital",
+    "value": "hospital"
+},{
+    "label": "Hotel",
+    "value": "hotel"
+},{
+    "label": "Other",
+    "value": "other"
+},{
+    "label": "Other GOvernment Facility (non-U.S.)",
+    "value": "otherGov"
+},{
+    "label": "Port",
+    "value": "port"
+},{
+    "label": "Restaurant",
+    "value": "restaurant"
+},{
+    "label": "Stadium",
+    "value": "stadium"
+},{
+    "label": "Train Station",
+    "value": "trainStation"
+},{
+    "label": "UN Facility",
+    "value": "unFacility"
+},{
+    "label": "USG Facility",
+    "value": "usgFacility"
+},{
+    "label": "School",
+    "value": "school"
 }]

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -31,14 +31,30 @@ type DropdownProps = {
 	 */
 	label: string
 	menuProps?: Omit<PseudoBoxProps, OmittedBoxProps>
+	/**
+	 * Highlights currently selected option
+	 * when dropdown is opened
+	 */
+	showSelected?: boolean
+	/**
+	 * Initially selected option
+	 * that will be highlighted
+	 *
+	 * (see `showSelected` property)
+	 */
+	initialSelection?: string
 }
 
 const Dropdown: React.FC<DropdownProps> = (p: DropdownProps) => {
 	const [isOpen, setOpen] = useState(false)
-	const { children, borderedRows, width = "buttonMd", options = [], label, menuProps } = p
+	const { children, borderedRows, width = "buttonMd", options = [], label, menuProps, showSelected, initialSelection } = p
 	const theme = useTheme()
 	const dropdownRef = useRef<HTMLDivElement>(null)
+	const [selectedVal, setSelectedVal] = useState<string | undefined>(initialSelection)
 
+	/**
+	 * Auto-close dropdown if user clicks outside it
+	 */
 	useEffect(() => {
 		const closeDropdown = (e: MouseEvent) => {
 			if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
@@ -172,19 +188,29 @@ const Dropdown: React.FC<DropdownProps> = (p: DropdownProps) => {
 					variants={menuMotion}>
 					{options.map((option: DropdownOptions, index) => {
 						const { onClick, value, label, type: type = "primary" } = option
+						const isSelected = showSelected && value === selectedVal
+						const hoverBg = type === "primary" ? "clickable" : "error"
+						const hoverColor = "white"
+
+						const colorProps: PseudoBoxProps = {
+							color: isSelected ? hoverColor : type === "primary" ? "text" : "error",
+							backgroundColor: isSelected ? hoverBg : undefined,
+							_hover: {
+								color: hoverColor,
+								backgroundColor: hoverBg,
+							},
+						}
+
 						return (
 							<PseudoBox
 								as={ListItem}
 								key={index}
 								{...listItemProps}
+								{...colorProps}
 								onClick={() => {
 									onClick && onClick(value, label)
+									setSelectedVal(value)
 									setOpen(!isOpen)
-								}}
-								color={type === "primary" ? "text" : "error"}
-								_hover={{
-									color: "white",
-									backgroundColor: type === "primary" ? "clickable" : "error",
 								}}>
 								{label}
 							</PseudoBox>

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useState, useEffect, useRef } from "react"
 import { Box, BoxProps, PseudoBox, PseudoBoxProps, Flex, List, ListItem, useTheme } from "@chakra-ui/core"
 import { motion } from "framer-motion"
 
@@ -37,6 +37,20 @@ const Dropdown: React.FC<DropdownProps> = (p: DropdownProps) => {
 	const [isOpen, setOpen] = useState(false)
 	const { children, borderedRows, width = "buttonMd", options = [], label, menuProps } = p
 	const theme = useTheme()
+	const dropdownRef = useRef<HTMLDivElement>(null)
+
+	useEffect(() => {
+		const closeDropdown = (e: MouseEvent) => {
+			if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+				setOpen(false)
+			}
+		}
+		document.addEventListener("click", closeDropdown)
+
+		return () => {
+			document.removeEventListener("click", closeDropdown)
+		}
+	}, [setOpen, dropdownRef])
 
 	const menuMotion = {
 		hidden: {
@@ -96,7 +110,7 @@ const Dropdown: React.FC<DropdownProps> = (p: DropdownProps) => {
 	}
 
 	return (
-		<Box position="relative">
+		<Box position="relative" ref={dropdownRef}>
 			<Flex display="inline-flex" align="center">
 				<PseudoBox
 					as="button"

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -55,7 +55,6 @@ const EventCard: React.FC<EventCardProps> = ({ data, onConfirm }: EventCardProps
 				const pageState: EventPageState = {
 					eventId: eventId,
 					isEdit: true,
-					formSection: "overview",
 				}
 				navigate("/event", { state: pageState })
 			},

--- a/src/components/EventForm.d.ts
+++ b/src/components/EventForm.d.ts
@@ -15,26 +15,26 @@ interface EventFormData extends Record<string, boolean | Date | string | number 
 	eventLklDtoList?: LklDto[]
 }
 
-interface EmailDto {
+interface EmailDto extends Record<string, string> {
 	emailId: string
 	emailAddress: string
 }
-interface PhoneDto {
+interface PhoneDto extends Record<string, string> {
 	phoneId: string
 	phoneNum: string
 	phoneTypeCd: string
 }
 
-interface PersonEmailDto {
+interface PersonEmailDto extends Record<string, string | EmailDto> {
 	personEmailId: string
 	emailDto: EmailDto
 }
-interface PersonPhoneDto {
+interface PersonPhoneDto extends Record<string, string | PhoneDto> {
 	personPhoneId: string
 	phoneDto: PhoneDto
 }
 
-interface PersonDto {
+interface PersonDto extends Record<string, string | PersonEmailDto[] | PersonPhoneDto[]> {
 	personId: string
 	givenName: string
 	surName: string
@@ -42,12 +42,12 @@ interface PersonDto {
 	personPhoneDtoList: PersonPhoneDto[]
 }
 
-interface LklPocListDto {
+interface LklPocListDto extends Record<string, string | PersonDto> {
 	lklPocId: string
 	personDto: PersonDto
 }
 
-interface AddressDto {
+interface AddressDto extends Record<string, string> {
 	addressId: string
 	addressTypeCd: string
 	address1: string
@@ -58,26 +58,26 @@ interface AddressDto {
 	stateCd: string
 }
 
-interface LklAddressDto {
+interface LklAddressDto extends Record<string, string | AddressDto> {
 	lklAddressId: string
 	addressDto: AddressDto
 }
 
-interface LookupLklDto {
+interface LookupLklDto extends Record<string, string | LklAddressDto | LklPocListDto[] | undefined> {
 	lookupLklId: string
 	lklTitle: string
-	locationDesc: string
+	locationDesc?: string
 	postCd: string
 	countryCd: string
-	lklAddressDto: LklAddressDto
-	lklPocListDto: LklPocListDto[]
+	lklAddressDto?: LklAddressDto
+	lklPocListDto?: LklPocListDto[]
 }
-interface LklDto {
+interface LklDto extends Record<string, string | boolean | Date | LookupLklDto | undefined> {
 	eventId: string
 	eventLklId: string
-	activeIndicator: boolean
-	lklTypeCd: string
-	createdDateTime: Date
-	lastUpdatedDateTime: Date
+	activeIndicator?: boolean
+	lklTypeCd?: string
+	createdDateTime?: Date
+	lastUpdatedDateTime?: Date
 	lookupLklDto: LookupLklDto
 }

--- a/src/components/FormSections/EventDetails.tsx
+++ b/src/components/FormSections/EventDetails.tsx
@@ -9,8 +9,13 @@ import eventTypes from "../../../content/eventTypes.json"
 import { FormSection, replaceMSWordChars, useCTFFormContext } from "../Forms/Form"
 import DeactivateModal from "../Modals/DeactivateModal"
 
-const EventDetails: React.FC = () => {
+interface EventDetailsProps {
+	hideTitle?: boolean
+}
+
+const EventDetails: React.FC<EventDetailsProps> = (p: EventDetailsProps) => {
 	const { isOpen: isDeactivateOpen, onOpen: onDeactivateOpen, onClose: onDeactivateClose } = useDisclosure()
+	const { hideTitle } = p
 
 	const { register, errors, setValue } = useFormContext<EventFormData>()
 
@@ -26,7 +31,7 @@ const EventDetails: React.FC = () => {
 	const { isView, isCreate } = useCTFFormContext()
 
 	return (
-		<FormSection title="Event Details" showDivider={isCreate}>
+		<FormSection title={hideTitle ? undefined : "Event Details"} showDivider={isCreate}>
 			<Box gridColumn={{ base: "1 / -1", lg: "span 9" }}>
 				<FormInput labelText="Event Title" labelId="eventTitleLabel" required>
 					<Text
@@ -123,7 +128,7 @@ const EventDetails: React.FC = () => {
 					/>
 				</FormInput>
 			</Grid>
-			<Box gridColumn={{ base: "1 / -1", md: "span 4" }}>
+			<Box gridColumn={{ base: "1 / -1", md: "1 / 5" }}>
 				<FormInput labelText="Management Type" labelId="managementTypeCodeLabel" required>
 					<Controller
 						name="managementTypeCode"
@@ -152,7 +157,7 @@ const EventDetails: React.FC = () => {
 					/>
 				</FormInput>
 			</Box>
-			<Box gridColumn={{ base: "1 / -1", md: "span 4" }}>
+			<Box gridColumn={{ base: "1 / -1", md: "1 / 5" }}>
 				<FormInput labelText="Event Type" labelId="eventTypeIdLabel" required>
 					<Controller
 						name="eventTypeId"

--- a/src/components/FormSections/LocationDetails.tsx
+++ b/src/components/FormSections/LocationDetails.tsx
@@ -6,7 +6,7 @@ import { Switch, Select, FormInput, Text, ValidationState, Textarea } from "@c1d
 import countries_json from "../../../content/countries.json"
 import posts from "../../../content/posts.json"
 import states from "../../../content/states.json"
-import locationTypes from "../../../content/locationTypes.json"
+import locationTypes_json from "../../../content/locationTypes.json"
 
 const LocationDetails: React.FC = () => {
 	const { trigger, register, errors, setValue, formState } = useFormContext<LklDto>()
@@ -34,6 +34,14 @@ const LocationDetails: React.FC = () => {
 		countriesList.sort((countryA, countryB) => countryA.label.localeCompare(countryB.label))
 		return countriesList
 	}, [])
+
+	const locationTypes = [
+		{
+			label: " ",
+			value: undefined,
+		},
+		...locationTypes_json.sort((locTypeA, locTypeB) => locTypeA.label.localeCompare(locTypeB.label)),
+	]
 
 	const isDisabled = false
 

--- a/src/components/FormSections/LocationDetails.tsx
+++ b/src/components/FormSections/LocationDetails.tsx
@@ -1,5 +1,4 @@
 import React, { useRef, useMemo } from "react"
-import { LKLFormData } from "../Forms/LKLForm"
 import { FormSection, replaceMSWordChars } from "../Forms/Form"
 import { Box, Grid } from "@chakra-ui/core"
 import { Controller, useFormContext, useWatch } from "react-hook-form"
@@ -10,7 +9,7 @@ import states from "../../../content/states.json"
 import locationTypes from "../../../content/locationTypes.json"
 
 const LocationDetails: React.FC = () => {
-	const { trigger, register, errors, setValue, formState } = useFormContext<LKLFormData>()
+	const { trigger, register, errors, setValue, formState } = useFormContext<LklDto>()
 	const { dirtyFields } = formState
 
 	const countryRef = useRef<HTMLButtonElement>(null)
@@ -93,15 +92,15 @@ const LocationDetails: React.FC = () => {
 				gridGap={{ base: "16px", md: "24px" }}
 				gridTemplateColumns={{ base: "1", md: "repeat(12,1fr)" }}>
 				<Box gridColumn={{ base: "1 / -1", md: "span 11" }}>
-					<FormInput labelText="Location Title" labelId="locationTitleLabel" required>
+					<FormInput labelText="Location Title" labelId="lklTitleLabel" required>
 						<Text
-							id="locationTitle"
-							name="locationTitle"
+							id="lklTitle"
+							name="lklTitle"
 							size="full"
 							disabled={isDisabled}
 							onChange={filterOnTextChange}
-							validationState={errors?.locationTitle ? ValidationState.ERROR : undefined}
-							errorMessage={errors?.locationTitle?.message}
+							validationState={errors?.lklTitle ? ValidationState.ERROR : undefined}
+							errorMessage={errors?.lklTitle?.message}
 							ref={register({
 								required: "Please enter a Location Title",
 								maxLength: { value: 50, message: "Location Title cannot exceed 25 characters" },

--- a/src/components/Forms/EventForm.tsx
+++ b/src/components/Forms/EventForm.tsx
@@ -78,15 +78,23 @@ const EventForm: React.FC<EventFormProps> = (p: EventFormProps) => {
 		[updateSavedForm, isEdit, onSaveOpen, onSaveClose, getValues]
 	)
 
+	let pageHeading, pageDescription
+	if (isEdit) {
+		if (formSection === "overview") {
+			pageHeading = "Edit Event Details"
+			pageDescription = "Edit the basic information related to the developing crisis."
+		} else {
+			pageHeading = "Edit Event Details"
+			pageDescription = "Edit the basic information related to the developing crisis."
+		}
+	} else {
+		pageHeading = "Create New Event"
+		pageDescription =
+			"Enter the basic information related to the developing crisis. You can add more details later as the event unfolds."
+	}
+
 	return (
-		<Layout
-			pageTitle="Event Details"
-			pageHeading={isEdit ? `${savedEvent?.eventTitle}` : "Create New Event"}
-			pageDescription={
-				isEdit
-					? ""
-					: "Enter the basic information related to the developing crisis. You can add more details later as the event unfolds."
-			}>
+		<Layout pageTitle="Event Details" pageHeading={pageHeading} pageDescription={pageDescription}>
 			{" "}
 			<FormProvider {...formMethods}>
 				<Form
@@ -98,7 +106,7 @@ const EventForm: React.FC<EventFormProps> = (p: EventFormProps) => {
 					noValidate={true}>
 					<input name="eventId" type="hidden" ref={register} />
 
-					{(isCreate || (isEdit && formSection === "overview")) && <EventDetails />}
+					{(isCreate || (isEdit && formSection === "overview")) && <EventDetails hideTitle={isEdit} />}
 
 					{(isCreate || (isEdit && formSection === "evacuation")) && <EvacDetails />}
 

--- a/src/components/Forms/EventForm.tsx
+++ b/src/components/Forms/EventForm.tsx
@@ -8,7 +8,7 @@ import { SaveModal } from "../Modals/SaveModal"
 import { useForm, FormProvider } from "react-hook-form"
 import { getSavedForm, useSavedForm } from "../../components/Utility/formHelpers"
 import { Form, useCTFFormContext } from "./Form"
-import Layout from "../../components/Layout"
+import Layout, { LayoutProps } from "../../components/Layout"
 import EvacDetails from "../FormSections/EvacDetails"
 import EventDetails from "../FormSections/EventDetails"
 import { EventPageState } from "../../pages/event"
@@ -78,14 +78,28 @@ const EventForm: React.FC<EventFormProps> = (p: EventFormProps) => {
 		[updateSavedForm, isEdit, onSaveOpen, onSaveClose, getValues]
 	)
 
-	let pageHeading, pageDescription
+	let pageHeading, pageDescription, breadcrumbs: LayoutProps["breadcrumbs"]
 	if (isEdit) {
 		if (formSection === "overview") {
 			pageHeading = "Edit Event Details"
 			pageDescription = "Edit the basic information related to the developing crisis."
+			breadcrumbs = [
+				{
+					label: "Event",
+					onClick: onDataLossOpen,
+				},
+				{ label: "Edit Event Details" },
+			]
 		} else {
 			pageHeading = "Edit Event Details"
 			pageDescription = "Edit the basic information related to the developing crisis."
+			breadcrumbs = [
+				{
+					label: "Event",
+					onClick: onDataLossOpen,
+				},
+				{ label: "Edit Event Details" },
+			]
 		}
 	} else {
 		pageHeading = "Create New Event"
@@ -94,8 +108,7 @@ const EventForm: React.FC<EventFormProps> = (p: EventFormProps) => {
 	}
 
 	return (
-		<Layout pageTitle="Event Details" pageHeading={pageHeading} pageDescription={pageDescription}>
-			{" "}
+		<Layout pageTitle="Event Details" pageHeading={pageHeading} pageDescription={pageDescription} breadcrumbs={breadcrumbs}>
 			<FormProvider {...formMethods}>
 				<Form
 					name="eventForm"

--- a/src/components/Forms/EventForm.tsx
+++ b/src/components/Forms/EventForm.tsx
@@ -69,13 +69,14 @@ const EventForm: React.FC<EventFormProps> = (p: EventFormProps) => {
 					// TODO: Once microservice is connected, use returned eventId/event data
 					const pageState: EventPageState = {
 						eventId: getValues("eventId"),
+						formSection,
 					}
 					navigate("/event", { state: pageState })
 					onSaveClose()
 				}
 			}, 2000)
 		},
-		[updateSavedForm, isEdit, onSaveOpen, onSaveClose, getValues]
+		[updateSavedForm, isEdit, onSaveOpen, onSaveClose, getValues, formSection]
 	)
 
 	let pageHeading, pageDescription, breadcrumbs: LayoutProps["breadcrumbs"]
@@ -150,6 +151,7 @@ const EventForm: React.FC<EventFormProps> = (p: EventFormProps) => {
 							} else {
 								const pageState: EventPageState = {
 									eventId: getValues("eventId"),
+									formSection,
 								}
 								navigate("/event", { state: pageState })
 							}

--- a/src/components/Forms/EventForm.tsx
+++ b/src/components/Forms/EventForm.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from "react"
 import { navigate } from "gatsby"
 import { Box, Flex, useDisclosure } from "@chakra-ui/core"
-import { Button, Banner, useBanner, Status, LinkButton } from "@c1ds/components"
+import { Button, LinkButton } from "@c1ds/components"
 import moment from "moment"
 import { DataLossModal } from "../Modals/DataLossModal"
 import { SaveModal } from "../Modals/SaveModal"
@@ -24,7 +24,6 @@ const EventForm: React.FC<EventFormProps> = (p: EventFormProps) => {
 	const { isOpen: isDataLossOpen, onOpen: onDataLossOpen, onClose: onDataLossClose } = useDisclosure()
 
 	const { isOpen: isSaveOpen, onOpen: onSaveOpen, onClose: onSaveClose } = useDisclosure()
-	const showSaveBanner = useBanner(saveBanner, 2)
 	const [, updateSavedForm] = useSavedForm<EventFormData[]>("ctfForms", "events")
 
 	const defaultValues = {
@@ -74,10 +73,9 @@ const EventForm: React.FC<EventFormProps> = (p: EventFormProps) => {
 					navigate("/event", { state: pageState })
 					onSaveClose()
 				}
-				showSaveBanner()
 			}, 2000)
 		},
-		[updateSavedForm, isEdit, onSaveOpen, onSaveClose, showSaveBanner, getValues]
+		[updateSavedForm, isEdit, onSaveOpen, onSaveClose, getValues]
 	)
 
 	return (
@@ -146,11 +144,5 @@ const EventForm: React.FC<EventFormProps> = (p: EventFormProps) => {
 		</Layout>
 	)
 }
-
-const saveBanner = (
-	<Banner status={Status.success} title="Save successful!" onClose={() => console.log("Banner closed")}>
-		{}
-	</Banner>
-)
 
 export default EventForm

--- a/src/components/Forms/Form.tsx
+++ b/src/components/Forms/Form.tsx
@@ -27,7 +27,7 @@ interface FormSectionProps {
 	/**
 	 * Section title
 	 */
-	title: string
+	title?: string
 	/**
 	 * Controls whether hr section separator is displayed at the end of the section
 	 */

--- a/src/components/Forms/LKLForm.tsx
+++ b/src/components/Forms/LKLForm.tsx
@@ -1,62 +1,38 @@
 import React from "react"
-import Layout from "../../components/Layout"
+import Layout, { LayoutProps } from "../../components/Layout"
 import { navigate } from "gatsby"
 import { FormProvider, useForm } from "react-hook-form"
 import { Button, LinkButton } from "@c1ds/components"
-import { Box, Grid } from "@chakra-ui/core"
-import { Form } from "./Form"
+import { Box, Grid, useDisclosure } from "@chakra-ui/core"
+import { Form, useCTFFormContext } from "./Form"
 import LocationDetails from "../FormSections/LocationDetails"
-
-export interface LKLFormData extends Record<string, boolean | string | number | LookupLklDto | undefined> {
-	eventId: number
-	eventLklId: number
-	activeIndicator: boolean
-	lklTypeCd: string
-	createdDateTime: string
-	lastUpdatedDateTime: string
-	lookupLklDto: LookupLklDto
-}
-
-interface LookupLklDto {
-	lookupLklId: number
-	lklTitle: string
-	locationDesc: string
-	postCd: string
-	countryCd: string
-	lklAddressDto: LklAddressDto
-}
-
-interface LklAddressDto {
-	lklAddressId: number
-	addressDto: AddressDto
-}
-
-interface AddressDto {
-	addressId: number
-	addressTypeCd: string
-	address1: string
-	address2: string
-	city: string
-	countryCd: string
-	postalCode: number
-	stateCd: string
-}
+import { DataLossModal } from "../Modals/DataLossModal"
+import { EventPageState } from "../../pages/event"
 
 interface LKLFormProps {
-	savedEvent?: LKLFormData
+	eventId: string
+	savedForm?: LklDto
 }
 
 const LKLForm: React.FC<LKLFormProps> = (p: LKLFormProps) => {
+	const { eventId, savedForm } = p
+	// const { isCreate, isEdit } = useCTFFormContext()
+	const { isOpen: isDataLossOpen, onOpen: onDataLossOpen, onClose: onDataLossClose } = useDisclosure()
+
 	const defaultValues = {
 		activeIndicator: true,
 	}
 
-	const formMethods = useForm<LKLFormData>({
+	const formMethods = useForm<LklDto>({
 		mode: "onBlur",
 		defaultValues: defaultValues,
 	})
 
-	const breadcrumbs = [{ label: "Event" }, { label: "Add Location" }, { label: "New Location" }]
+	const breadcrumbs: LayoutProps["breadcrumbs"] = [
+		{ label: "Event", onClick: onDataLossOpen },
+		{ label: "Add Location" },
+		{ label: "New Location" },
+	]
 
 	return (
 		<Layout
@@ -95,9 +71,24 @@ const LKLForm: React.FC<LKLFormProps> = (p: LKLFormProps) => {
 							</Button>
 						</Box>
 						<Box gridColumn={{ base: "1 / -1", md: "1 / 2" }} gridRow={{ md: "1" }} justifySelf="center">
-							<LinkButton onClick={() => navigate("/")}>Cancel</LinkButton>
+							<LinkButton type="button" onClick={onDataLossOpen}>
+								Cancel
+							</LinkButton>
 						</Box>
 					</Grid>
+
+					<DataLossModal
+						isOpen={isDataLossOpen}
+						onClose={onDataLossClose}
+						onLeave={() => {
+							const pageState: EventPageState = {
+								// TODO: Uncomment once form integration is established
+								// eventId: getValues("eventId"),
+								eventId: eventId,
+							}
+							navigate("/event", { state: pageState })
+						}}
+					/>
 				</Form>
 			</FormProvider>
 		</Layout>

--- a/src/components/Forms/LKLForm.tsx
+++ b/src/components/Forms/LKLForm.tsx
@@ -85,6 +85,7 @@ const LKLForm: React.FC<LKLFormProps> = (p: LKLFormProps) => {
 								// TODO: Uncomment once form integration is established
 								// eventId: getValues("eventId"),
 								eventId: eventId,
+								formSection: "locations",
 							}
 							navigate("/event", { state: pageState })
 						}}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -8,7 +8,7 @@ import { Flex } from "@chakra-ui/core"
 
 import Main, { MainProps } from "./Main"
 
-type LayoutProps = {
+export type LayoutProps = {
 	children: React.ReactNode
 } & MainProps
 

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -41,13 +41,13 @@ const Main: React.FC<MainProps> = ({ children, pageHeading, pageTitle, pageDescr
 	return (
 		<Grid
 			as="main"
-			gridColumn="1 / -1"
+			alignContent="start"
 			gridGap={{ base: "16px", md: "24px" }}
 			gridTemplateColumns={{ base: "repeat(4, 1fr)", md: "repeat(8, 1fr)", lg: "repeat(12, 1fr)" }}
 			bg="white"
 			w="full"
 			maxW={{ xl: "1280px" }}
-			m={{ xl: "auto" }}
+			mx={{ xl: "auto" }}
 			paddingX={{ base: "16", md: "24" }}
 			paddingTop={{ base: "16", md: "24" }}
 			paddingBottom={{ base: "64", md: "96" }}

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import SEO from "./seo"
-import { Box, Grid, Flex, Text, Breadcrumb } from "@chakra-ui/core"
+import { Box, Grid, Flex, Text } from "@chakra-ui/core"
 import { H1, P, Link } from "@c1ds/components"
 
 interface Breadcrumb {
@@ -12,7 +12,7 @@ interface Breadcrumb {
 	 * Indicates if breadcrumb
 	 * is for current page
 	 */
-	onClick?: React.MouseEventHandler<HTMLButtonElement>
+	onClick?: React.MouseEventHandler<HTMLAnchorElement>
 }
 
 export interface MainProps {
@@ -39,61 +39,60 @@ export interface MainProps {
 
 const Main: React.FC<MainProps> = ({ children, pageHeading, pageTitle, pageDescription, breadcrumbs }: MainProps) => {
 	return (
-		<Box as="main" w="full" lineHeight="1.5">
+		<Grid
+			as="main"
+			gridColumn="1 / -1"
+			gridGap={{ base: "16px", md: "24px" }}
+			gridTemplateColumns={{ base: "repeat(4, 1fr)", md: "repeat(8, 1fr)", lg: "repeat(12, 1fr)" }}
+			bg="white"
+			w="full"
+			maxW={{ xl: "1280px" }}
+			m={{ xl: "auto" }}
+			paddingX={{ base: "16", md: "24" }}
+			paddingTop={{ base: "16", md: "24" }}
+			paddingBottom={{ base: "64", md: "96" }}
+			lineHeight="normal">
 			<SEO title={pageTitle} />
 
-			<Grid
-				as="section"
-				id="pageSection"
-				gridColumn="1 / -1"
-				gridGap={{ base: "16px", md: "24px" }}
-				gridTemplateColumns={["repeat(4, 1fr)", "repeat(4, 1fr)", "repeat(4, 1fr)", "repeat(8, 1fr)", "repeat(12, 1fr)"]}
-				bg="white"
-				maxW={{ xl: "1280px" }}
-				m={{ xl: "auto" }}
-				paddingX={{ base: "16", md: "24" }}
-				paddingTop={{ base: "16", md: "24" }}
-				paddingBottom={{ base: "64", md: "96" }}>
-				<Box gridColumn="1 / -1">
-					{breadcrumbs && (
-						<Box as="nav" fontSize="breadcrumb" lineHeight="normal" marginBottom={16}>
-							<Box as="ol" padding={0} margin={0}>
-								{breadcrumbs.map((breadcrumb, index) => (
-									<Flex as="li" display="inline-flex" align="baseline" key={index}>
-										{index < breadcrumbs.length - 1 ? (
-											<>
-												<Link onClick={breadcrumb.onClick}>{breadcrumb.label}</Link>
-												<Box as="span" role="presentation" marginX={8}>
-													&gt;
-												</Box>
-											</>
-										) : (
-											<Text
-												fontFamily="default"
-												color={"text"}
-												fontWeight="normal"
-												lineHeight="normal"
-												margin={0}>
-												{breadcrumb.label}
-											</Text>
-										)}
-									</Flex>
-								))}
-							</Box>
+			<Box gridColumn="1 / -1">
+				{breadcrumbs && (
+					<Box as="nav" fontSize="breadcrumb" lineHeight="normal" marginBottom={16}>
+						<Box as="ol" padding={0} margin={0}>
+							{breadcrumbs.map((breadcrumb, index) => (
+								<Flex as="li" display="inline-flex" align="baseline" key={index}>
+									{index < breadcrumbs.length - 1 ? (
+										<>
+											<Link onClick={breadcrumb.onClick}>{breadcrumb.label}</Link>
+											<Box as="span" role="presentation" marginX={8}>
+												&gt;
+											</Box>
+										</>
+									) : (
+										<Text
+											fontFamily="default"
+											color={"text"}
+											fontWeight="normal"
+											lineHeight="normal"
+											margin={0}>
+											{breadcrumb.label}
+										</Text>
+									)}
+								</Flex>
+							))}
 						</Box>
-					)}
-					<Box wordBreak="break-all">
-						<H1>{pageHeading}</H1>
 					</Box>
-					{pageDescription && (
-						<Box marginTop="12">
-							<P>{pageDescription}</P>
-						</Box>
-					)}
+				)}
+				<Box wordBreak="break-all">
+					<H1>{pageHeading}</H1>
 				</Box>
-				{children}
-			</Grid>
-		</Box>
+				{pageDescription && (
+					<Box marginTop="12">
+						<P>{pageDescription}</P>
+					</Box>
+				)}
+			</Box>
+			{children}
+		</Grid>
 	)
 }
 

--- a/src/components/Modals/DataLossModal.tsx
+++ b/src/components/Modals/DataLossModal.tsx
@@ -23,7 +23,7 @@ export const DataLossModal: React.FC<DataLossModalProps> = (p: DataLossModalProp
 				<Box marginRight="20">
 					<LinkButton onClick={p.onLeave}>Leave</LinkButton>
 				</Box>
-				<Button size="sm" onClick={p.onClose}>
+				<Button size="sm" onClick={p.onClose} buttonType="secondary">
 					Stay
 				</Button>
 			</Flex>

--- a/src/components/PageSections/EventEvacDetailsTab.tsx
+++ b/src/components/PageSections/EventEvacDetailsTab.tsx
@@ -86,4 +86,4 @@ const formatDateField = (inputDate: Date | undefined) => {
 	return inputDate ? moment(inputDate).format("MM/DD/YYYY") : ""
 }
 
-const displayData = (value?: string) => (value ? value : "---")
+const displayData = (value?: string) => (value ? value : "-")

--- a/src/components/PageSections/EventLklTab.tsx
+++ b/src/components/PageSections/EventLklTab.tsx
@@ -7,6 +7,7 @@ import { P, H3, C1_DATE_FORMAT as DateFormat, LinkButton, IconAlignment } from "
 
 import LKLCard from "../LKLCard"
 import HideInactiveButton from "../HideInactiveButton"
+import { LklPageState } from "../../pages/addLKL"
 
 import Pagination from "@material-ui/lab/Pagination"
 import { AddSharp } from "@material-ui/icons"
@@ -15,7 +16,7 @@ const DateTimeFormat = `${DateFormat} HH:mm:ss:SS ZZ`
 
 interface LastKnownLocationTabProps {
 	eventData: EventFormData
-	setEventData: (eventdata : EventFormData) => void
+	setEventData: (eventdata: EventFormData) => void
 }
 
 export const LastKnownLocationTab: React.FC<LastKnownLocationTabProps> = (p: LastKnownLocationTabProps) => {
@@ -85,12 +86,17 @@ export const LastKnownLocationTab: React.FC<LastKnownLocationTabProps> = (p: Las
 				<Box display={{ base: "none", md: "block" }}>
 					<LinkButton
 						buttonIcon={{ mdIcon: AddSharp, alignment: IconAlignment.LEFT, color: "clickable" }}
-						onClick={() => navigate("/addLKL")}>
+						onClick={() => {
+							const pageState: LklPageState = {
+								eventId: eventData.eventId,
+							}
+							navigate("/addLKL", { state: pageState })
+						}}>
 						&nbsp;Add Location
 					</LinkButton>
 				</Box>
 			</Flex>
-			<Box gridColumn="1 / -1"  mt={-16}>
+			<Box gridColumn="1 / -1" mt={-16}>
 				<P>Manage the last known locations for U.S. citizens involved in this crisis.</P>
 			</Box>
 			{/* 1.8     The user can set “Hide Inactive Location” to NO to view all 
@@ -129,7 +135,7 @@ export const LastKnownLocationTab: React.FC<LastKnownLocationTabProps> = (p: Las
 				gridRow={{ base: "3", md: "auto" }}
 				justify={{ base: "flex-start", md: "flex-end" }}>
 				<HideInactiveButton onToggleHideInactive={() => setHideInactive(!hideInactive)} />
-			</Flex> 
+			</Flex>
 
 			{lklsOnPage.map((lklData: LklDto, index) => {
 				return (

--- a/src/components/PageSections/EventOverviewTab.tsx
+++ b/src/components/PageSections/EventOverviewTab.tsx
@@ -24,6 +24,9 @@ export const OverviewTab: React.FC<OverviewTabProps> = (p: OverviewTabProps) => 
 	const eventType = eventTypes.find((eventType: Option) => eventType.value === eventData.eventTypeId)?.label
 	const mgmtType = mgmtTypes.find((mgmtType: Option) => mgmtType.value === eventData.managementTypeCode)?.label
 	const evacStatus = evacStatuses.find((evaStatus: Option) => evaStatus.value === eventData.evacStatusCode)?.label
+
+	const isActive = !!eventData.activeIndicator
+
 	return (
 		<>
 			<Grid
@@ -53,31 +56,45 @@ export const OverviewTab: React.FC<OverviewTabProps> = (p: OverviewTabProps) => 
 						</LinkButton>
 					</Box>
 				</Flex>
-				<Box gridColumn={{ base: "span 2" }}>
+				<Box gridColumn={{ base: "span 2", md: "span 4", lg: "span 2" }}>
+					<Box mb={4}>
+						<FinePrint color="label">Status</FinePrint>
+					</Box>
+					<Text
+						fontFamily="default"
+						color={isActive ? "success" : "error"}
+						fontSize="base"
+						fontWeight="h3"
+						lineHeight="normal"
+						margin={0}>
+						{displayData(isActive ? "Active" : "Inactive")}
+					</Text>
+				</Box>
+				<Box gridColumn={{ base: "span 2", md: "span 4", lg: "7 / 9" }} gridRow={{ md: "3", lg: "auto" }}>
 					<Box mb={4}>
 						<FinePrint color="label">Event Type</FinePrint>
 					</Box>
 					<P>{displayData(eventType)}</P>
 				</Box>
-				<Box gridColumn={{ base: "span 2", md: "span 3" }}>
-					<Box mb={4}>
-						<FinePrint color="label">Management Type</FinePrint>
-					</Box>
-					<P>{displayData(mgmtType)}</P>
-				</Box>
-				<Box gridColumn={{ base: "span 2", lg: "span 3" }}>
+				<Box gridColumn={{ base: "span 2", md: "span 4", lg: "3 / 5" }} gridRow={{ lg: "2" }}>
 					<Box mb={4}>
 						<FinePrint color="label">Start Date</FinePrint>
 					</Box>
 					<P>{displayData(formatDateField(eventData.eventStartDate))}</P>
 				</Box>
-				<Box gridColumn={{ base: "span 2" }}>
+				<Box gridColumn={{ base: "span 2", md: "span 4", lg: "5 / 7" }} gridRow={{ lg: "2" }}>
 					<Box mb={4}>
 						<FinePrint color="label">End Date</FinePrint>
 					</Box>
 					<P>{displayData(formatDateField(eventData.eventEndDate))}</P>
 				</Box>
-				<Box gridColumn={{ base: "1 / -1", md: "span 2" }} justifySelf={{ md: "center" }}>
+				<Box gridColumn={{ base: "span 2", md: "span 4", lg: "span 2" }}>
+					<Box mb={4}>
+						<FinePrint color="label">Management Type</FinePrint>
+					</Box>
+					<P>{displayData(mgmtType)}</P>
+				</Box>
+				<Box gridColumn={{ base: "span 2", md: "span 4", lg: "span 2" }}>
 					<Box mb={4}>
 						<FinePrint color="label">Evacuation Status</FinePrint>
 					</Box>

--- a/src/components/PageSections/EventOverviewTab.tsx
+++ b/src/components/PageSections/EventOverviewTab.tsx
@@ -158,4 +158,4 @@ const formatDateField = (inputDate: Date | undefined) => {
 	return inputDate ? moment(inputDate).format("MM/DD/YYYY") : ""
 }
 
-const displayData = (value?: string) => (value ? value : "---")
+const displayData = (value?: string) => (value ? value : "-")

--- a/src/components/PageSections/EventOverviewTab.tsx
+++ b/src/components/PageSections/EventOverviewTab.tsx
@@ -143,27 +143,22 @@ export const OverviewTab: React.FC<OverviewTabProps> = (p: OverviewTabProps) => 
 					lg: "repeat(12, 1fr)",
 				}}>
 				<Box gridColumn="1 / -1">
-					<H3>Impacted Area</H3>
+					<H3>Impacted Posts</H3>
 				</Box>
 				<Box gridColumn="1 / -1">
 					<P>
 						<Text color="required" as="span">
 							*&nbsp;
 						</Text>
-						Which Consular Posts are impacted by this event?
-					</P>
-				</Box>
-				<Box gridColumn={{ base: "1 / -1" }} marginTop={{ base: "0" }}>
-					<P>See below to help identify where Consular Districts are located in each country.</P>
-					<Box fontSize="button">
+						Which Consular Posts are impacted by this event?&nbsp; For a list of posts,{" "}
 						<Link
 							href="http://fam.a.state.sbu/fam/02FAM/02FAM0460.html#M463"
 							target="_blank"
 							rel="noreferrer noopener">
-							2 FAM EXHIBIT 461&nbsp; CONSULAR DISTRICTS
+							consult the FAM
 						</Link>
-					</Box>
-					{/* <P>{displayData(eventData.eventSummary)}</P> */}
+						.
+					</P>
 				</Box>
 			</Grid>
 		</>

--- a/src/components/PageSections/EventOverviewTab.tsx
+++ b/src/components/PageSections/EventOverviewTab.tsx
@@ -62,7 +62,7 @@ export const OverviewTab: React.FC<OverviewTabProps> = (p: OverviewTabProps) => 
 					</Box>
 					<Text
 						fontFamily="default"
-						color={isActive ? "success" : "error"}
+						color={isActive ? "success" : "label"}
 						fontSize="base"
 						fontWeight="h3"
 						lineHeight="normal"

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -29,7 +29,7 @@ const SearchInput: React.FC<SearchInputProps> = ({ searchTerm, onSearchEvent }: 
 					px="inputX"
 					width="auto"
 					height="input"
-					children={<Box as={SearchIcon} color="accent" role="presentation" size="iconMd" />}
+					children={<Box as={SearchIcon} color="clickable" role="presentation" size="iconMd" />}
 				/>
 
 				<Input

--- a/src/components/SortFilter.tsx
+++ b/src/components/SortFilter.tsx
@@ -43,7 +43,9 @@ const SortFilter: React.FC<SortFilterProps> = ({ sortByText, sortOption, onToggl
 						menuProps={{
 							marginTop: "4",
 							right: -20,
-						}}>
+						}}
+						initialSelection={getOptionsValue(sortByText)}
+						showSelected>
 						<Box as="span" fontSize="base" marginRight={2} cursor="pointer">
 							Sort by
 						</Box>

--- a/src/components/SortFilter.tsx
+++ b/src/components/SortFilter.tsx
@@ -4,7 +4,7 @@ import { navigate } from "gatsby"
 import { Button } from "@c1ds/components"
 import Dropdown, { DropdownOptions } from "./Dropdown"
 import { AddSharp, ArrowDropUpSharp, ArrowDropDownSharp } from "@material-ui/icons"
-import { Box, Flex, Button as ChakraButton } from "@chakra-ui/core"
+import { Box, PseudoBox, Flex, Button as ChakraButton, useTheme } from "@chakra-ui/core"
 
 type SortFilterProps = {
 	sortByText: string
@@ -16,6 +16,8 @@ type SortFilterProps = {
  * SortFilter component for sorting the event list based on a filter (ASC/DESC).
  */
 const SortFilter: React.FC<SortFilterProps> = ({ sortByText, sortOption, onToggleSortBy }: SortFilterProps) => {
+	const theme = useTheme()
+
 	// Sort option labels, values and onClick event handlers. Order is identical to the option menu
 	const options: DropdownOptions[] = [
 		{ label: "Event Type", value: "eventTypeId", onClick: onToggleSortBy },
@@ -70,35 +72,51 @@ const SortFilter: React.FC<SortFilterProps> = ({ sortByText, sortOption, onToggl
 							/>
 						</Flex>
 					) : sortOption[0] === "-" ? (
-						<Box display="inline-flex">
-							<Box
-								as={ArrowDropDownSharp}
-								aria-label={`Sort by ${sortByText} ascending`}
-								size="iconLg"
-								cursor="pointer"
-								color="clickable"
-								ml={-4}
-								onClick={e => {
-									e.stopPropagation()
-									onToggleSortBy(getOptionsValue(sortByText), sortOption.substring(1))
-								}}
-							/>
-						</Box>
+						<PseudoBox
+							as="button"
+							// @ts-ignore
+							type="button"
+							display="inline-flex"
+							alignItems="center"
+							justifyContent="center"
+							padding={0}
+							border="none"
+							background="none"
+							size="iconMd"
+							cursor="pointer"
+							aria-label={`Sort by ${sortByText} ascending`}
+							onClick={() => {
+								onToggleSortBy(getOptionsValue(sortByText), sortOption.substring(1))
+							}}
+							_focus={{
+								// @ts-ignore
+								outline: `1px dashed ${theme.colors.accent}`,
+							}}>
+							<Box as={ArrowDropDownSharp} size="icon" transform="scale(2)" color="clickable" />
+						</PseudoBox>
 					) : (
-						<Box display="inline-flex">
-							<Box
-								as={ArrowDropUpSharp}
-								aria-label={`Sort by ${sortByText} descending`}
-								size="iconLg"
-								cursor="pointer"
-								color="clickable"
-								ml={-4}
-								onClick={e => {
-									e.stopPropagation()
-									onToggleSortBy(getOptionsValue(sortByText), sortOption)
-								}}
-							/>
-						</Box>
+						<PseudoBox
+							as="button"
+							// @ts-ignore
+							type="button"
+							display="inline-flex"
+							alignItems="center"
+							justifyContent="center"
+							padding={0}
+							border="none"
+							background="none"
+							size="iconMd"
+							cursor="pointer"
+							aria-label={`Sort by ${sortByText} descending`}
+							onClick={() => {
+								onToggleSortBy(getOptionsValue(sortByText), sortOption)
+							}}
+							_focus={{
+								// @ts-ignore
+								outline: `1px dashed ${theme.colors.accent}`,
+							}}>
+							<Box as={ArrowDropUpSharp} size="icon" transform="scale(2)" color="clickable" />
+						</PseudoBox>
 					)}
 				</Flex>
 			</Box>

--- a/src/components/ViewEvent.tsx
+++ b/src/components/ViewEvent.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from "react"
-import { Box, BoxProps, Flex, Grid, Divider, PseudoBox, useTheme } from "@chakra-ui/core"
-import SEO from "./seo"
-import { H1, Select } from "@c1ds/components"
+import { Box, BoxProps, Divider, PseudoBox, useTheme } from "@chakra-ui/core"
+import { Select } from "@c1ds/components"
 import { EventFormSections } from "./Forms/Form"
 import { OverviewTab } from "./PageSections/EventOverviewTab"
 import { LastKnownLocationTab } from "./PageSections/EventLklTab"
 import { EvacDetailsTab } from "./PageSections/EventEvacDetailsTab"
 import { AttachmentsTab } from "./PageSections/EventAttachmentsTab"
+import Layout from "./Layout"
 
 interface EventFormProps {
 	savedEvent?: EventFormData
@@ -32,111 +32,62 @@ const ViewEvent: React.FC<EventFormProps> = (p: EventFormProps) => {
 		inEvacuation = selectedTab === "evacuation",
 		inAttachments = selectedTab === "attachments"
 
-	const isActive = !!eventData.activeIndicator
-
 	return (
-		<Flex minH="100vh">
-			<Box as="main" w="full" lineHeight="1.5">
-				<SEO title="View Event" />
-
-				<Grid
-					as="section"
-					id="pageSection"
-					gridColumn="1 / -1"
-					gridGap={{ base: "16px", md: "24px" }}
-					gridTemplateColumns={[
-						"repeat(4, 1fr)",
-						"repeat(4, 1fr)",
-						"repeat(4, 1fr)",
-						"repeat(8, 1fr)",
-						"repeat(12, 1fr)",
-					]}
-					bg="white"
-					maxW={{ xl: "1280px" }}
-					m={{ xl: "auto" }}
-					paddingX={{ base: "16", md: "24" }}
-					paddingTop={{ base: "16", md: "24" }}
-					paddingBottom={{ base: "64", md: "96" }}>
-					<Box gridColumn="1 / -1">
-						<Flex align="center" justifyContent="space-between">
-							<Box wordBreak="break-word" marginRight="16">
-								<H1>{eventData.eventTitle}</H1>
-							</Box>
-
-							<Flex
-								flexShrink={0}
-								justifySelf="end"
-								alignSelf="center"
-								width={{ base: "74px", sm: "93px" }}
-								fontFamily="default"
-								fontSize="finePrint"
-								align="center"
-								justify="center"
-								rounded="chip"
-								backgroundColor={isActive ? "success" : "disabledBackground"}
-								height="32px"
-								color={isActive ? "white" : "disabledButtonText"}
-								border={isActive ? "none" : "px"}
-								borderColor="disabledBorder"
-								paddingY={0}>
-								{isActive ? "Active" : "Inactive"}
-							</Flex>
-						</Flex>
-						<Box marginTop="12" display={{ md: "none" }}>
-							<Select
-								id="eventTab"
-								name="eventTab"
-								aria-label="Event Tab"
-								options={eventTabs}
-								size="full"
-								onChange={changes => {
-									setSelectedTab(changes.selectedItem?.value as EventFormSections)
-								}}
-								value={selectedTab}
-							/>
-						</Box>
-						<Box marginTop="12" display={{ base: "none", md: "block" }}>
-							<TabButton
-								isActive={inOverview}
-								onClick={() => setSelectedTab("overview")}
-								marginRight={{ base: "48", xl: "72" }}>
-								Event Overview
-							</TabButton>
-							<TabButton
-								isActive={inLkl}
-								onClick={() => setSelectedTab("locations")}
-								marginRight={{ base: "48", xl: "72" }}>
-								Last Known Locations
-							</TabButton>
-							<TabButton
-								isActive={inEvacuation}
-								onClick={() => setSelectedTab("evacuation")}
-								marginRight={{ base: "48", xl: "72" }}>
-								Evacuation
-							</TabButton>
-							<TabButton
-								isActive={inAttachments}
-								onClick={() => setSelectedTab("attachments")}
-								marginRight={{ base: "48", xl: "72" }}>
-								Attachments
-							</TabButton>
-						</Box>
-						<Box gridColumn="1 / -1" marginTop={{ base: "16", md: "-3px" }} marginBottom="16">
-							<Divider borderColor="disabledDark" marginY="2" marginX={0} opacity={1} />
-						</Box>
-						{inLkl ? (
-							<LastKnownLocationTab eventData={currentEventData} setEventData={setEventData} />
-						) : inEvacuation ? (
-							<EvacDetailsTab eventData={eventData} />
-						) : inAttachments ? (
-							<AttachmentsTab eventData={eventData} />
-						) : (
-							<OverviewTab eventData={eventData} />
-						)}
-					</Box>
-				</Grid>
+		<Layout pageTitle="View Event" pageHeading={eventData.eventTitle}>
+			<Box gridColumn="1 / -1">
+				<Box marginTop="12" display={{ md: "none" }}>
+					<Select
+						id="eventTab"
+						name="eventTab"
+						aria-label="Event Tab"
+						options={eventTabs}
+						size="full"
+						onChange={changes => {
+							setSelectedTab(changes.selectedItem?.value as EventFormSections)
+						}}
+						value={selectedTab}
+					/>
+				</Box>
+				<Box marginTop="12" display={{ base: "none", md: "block" }}>
+					<TabButton
+						isActive={inOverview}
+						onClick={() => setSelectedTab("overview")}
+						marginRight={{ base: "48", xl: "72" }}>
+						Event Overview
+					</TabButton>
+					<TabButton
+						isActive={inLkl}
+						onClick={() => setSelectedTab("locations")}
+						marginRight={{ base: "48", xl: "72" }}>
+						Last Known Locations
+					</TabButton>
+					<TabButton
+						isActive={inEvacuation}
+						onClick={() => setSelectedTab("evacuation")}
+						marginRight={{ base: "48", xl: "72" }}>
+						Evacuation
+					</TabButton>
+					<TabButton
+						isActive={inAttachments}
+						onClick={() => setSelectedTab("attachments")}
+						marginRight={{ base: "48", xl: "72" }}>
+						Attachments
+					</TabButton>
+				</Box>
+				<Box gridColumn="1 / -1" marginTop={{ base: "16", md: "-3px" }} marginBottom="16">
+					<Divider borderColor="disabledDark" marginY="2" marginX={0} opacity={1} />
+				</Box>
+				{inLkl ? (
+					<LastKnownLocationTab eventData={currentEventData} setEventData={setEventData} />
+				) : inEvacuation ? (
+					<EvacDetailsTab eventData={eventData} />
+				) : inAttachments ? (
+					<AttachmentsTab eventData={eventData} />
+				) : (
+					<OverviewTab eventData={eventData} />
+				)}
 			</Box>
-		</Flex>
+		</Layout>
 	)
 }
 

--- a/src/components/ViewEvent.tsx
+++ b/src/components/ViewEvent.tsx
@@ -33,6 +33,11 @@ const ViewEvent: React.FC<EventFormProps> = (p: EventFormProps) => {
 		inEvacuation = selectedTab === "evacuation",
 		inAttachments = selectedTab === "attachments"
 
+	const handleTabClick = (e: React.MouseEvent<HTMLButtonElement>, tab: EventFormSections) => {
+		setSelectedTab(tab)
+		e.currentTarget.blur()
+	}
+
 	return (
 		<Layout pageTitle="View Event" pageHeading={eventData.eventTitle}>
 			<Box gridColumn="1 / -1">
@@ -52,25 +57,25 @@ const ViewEvent: React.FC<EventFormProps> = (p: EventFormProps) => {
 				<Box marginTop="12" display={{ base: "none", md: "block" }}>
 					<TabButton
 						isActive={inOverview}
-						onClick={() => setSelectedTab("overview")}
+						onClick={e => handleTabClick(e, "overview")}
 						marginRight={{ base: "48", xl: "72" }}>
 						Event Overview
 					</TabButton>
 					<TabButton
 						isActive={inLkl}
-						onClick={() => setSelectedTab("locations")}
+						onClick={e => handleTabClick(e, "locations")}
 						marginRight={{ base: "48", xl: "72" }}>
 						Last Known Locations
 					</TabButton>
 					<TabButton
 						isActive={inEvacuation}
-						onClick={() => setSelectedTab("evacuation")}
+						onClick={e => handleTabClick(e, "evacuation")}
 						marginRight={{ base: "48", xl: "72" }}>
 						Evacuation
 					</TabButton>
 					<TabButton
 						isActive={inAttachments}
-						onClick={() => setSelectedTab("attachments")}
+						onClick={e => handleTabClick(e, "attachments")}
 						marginRight={{ base: "48", xl: "72" }}>
 						Attachments
 					</TabButton>
@@ -98,7 +103,7 @@ type TabButtonProps = {
 	 * Indicates if tab is currently active
 	 */
 	isActive?: boolean
-} & BoxProps
+} & Omit<BoxProps, "onClick">
 
 const TabButton: React.FC<TabButtonProps> = p => {
 	const { onClick, isActive, children, ...boxProps } = p

--- a/src/components/ViewEvent.tsx
+++ b/src/components/ViewEvent.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react"
 import { Box, BoxProps, Divider, PseudoBox, useTheme } from "@chakra-ui/core"
 import { Select } from "@c1ds/components"
-import { EventFormSections } from "./Forms/Form"
+import { EventFormSections, useCTFFormContext } from "./Forms/Form"
 import { OverviewTab } from "./PageSections/EventOverviewTab"
 import { LastKnownLocationTab } from "./PageSections/EventLklTab"
 import { EvacDetailsTab } from "./PageSections/EventEvacDetailsTab"
@@ -21,12 +21,13 @@ const eventTabs: { label: string; value: EventFormSections }[] = [
 
 const ViewEvent: React.FC<EventFormProps> = (p: EventFormProps) => {
 	const { savedEvent } = p
+	const { formSection } = useCTFFormContext()
 
 	const [currentEventData, setEventData] = useState(savedEvent)
 
 	const eventData: EventFormData = savedEvent ?? { eventId: "", eventTitle: "", managementTypeCode: "", eventTypeId: "" }
 
-	const [selectedTab, setSelectedTab] = useState<EventFormSections | undefined>("overview")
+	const [selectedTab, setSelectedTab] = useState<EventFormSections | undefined>(formSection)
 	const inOverview = selectedTab === "overview",
 		inLkl = selectedTab === "locations",
 		inEvacuation = selectedTab === "evacuation",

--- a/src/pages/addLKL.tsx
+++ b/src/pages/addLKL.tsx
@@ -1,15 +1,37 @@
 import React from "react"
-import { CTFFormProvider } from "../components/Forms/Form"
-import LKLForm, { LKLFormData } from "../components/Forms/LKLForm"
+import moment from "moment"
+import { getSavedForm } from "../components/Utility/formHelpers"
+import { CTFFormProvider, CTFFormProviderProps } from "../components/Forms/Form"
+import LKLForm from "../components/Forms/LKLForm"
 
-interface LKLFormProps {
-	savedEvent?: LKLFormData
+export interface LklPageState {
+	eventId: string
+	eventLklId?: string
 }
 
-const addLKLPage: React.FC<LKLFormProps> = (p: LKLFormProps) => {
+type LklPageProps = {
+	location: {
+		state: LklPageState
+	}
+}
+
+const addLKLPage: React.FC<LklPageProps> = (p: LklPageProps) => {
+	let savedLkl: LklDto | undefined
+	if (p.location?.state?.eventLklId) {
+		const savedEvents = getSavedForm<Array<EventFormData>>("ctfForms", "events")
+		const savedEvent = savedEvents && savedEvents.find((event: EventFormData) => event.eventId === p.location?.state?.eventId)
+		savedLkl = savedEvent?.eventLklDtoList?.find((lklDto: LklDto) => lklDto.eventLklId === p.location?.state?.eventLklId)
+		if (savedLkl) {
+			if (savedLkl.createdDateTime) savedLkl.createdDateTime = moment(savedLkl.createdDateTime).toDate()
+			if (savedLkl.lastUpdatedDateTime) savedLkl.lastUpdatedDateTime = moment(savedLkl.lastUpdatedDateTime).toDate()
+		}
+	}
+
+	const formMode: CTFFormProviderProps["formMode"] = typeof savedLkl === "undefined" ? "create" : "edit"
+
 	return (
-		<CTFFormProvider formMode="view">
-			<LKLForm />
+		<CTFFormProvider formMode={formMode}>
+			<LKLForm eventId={p.location?.state?.eventId} savedForm={savedLkl} />
 		</CTFFormProvider>
 	)
 }

--- a/src/pages/event.tsx
+++ b/src/pages/event.tsx
@@ -6,13 +6,12 @@ import EventForm from "../components/Forms/EventForm"
 import ViewEvent from "../components/ViewEvent"
 
 export interface EventPageState {
-	eventId: string
+	eventId?: string
 	isEdit?: boolean
 	formSection?: CTFFormProviderProps["formSection"]
 }
 
 type EventPageProps = {
-	eventId: string
 	location: {
 		state: EventPageState
 	}

--- a/src/pages/event.tsx
+++ b/src/pages/event.tsx
@@ -17,6 +17,8 @@ type EventPageProps = {
 	}
 }
 
+const DEFAULT_SECTION: CTFFormProviderProps["formSection"] = "overview"
+
 const EventPage: React.FC<EventPageProps> = (p: EventPageProps) => {
 	let savedEvent: EventFormData | undefined
 	if (p.location?.state?.eventId) {
@@ -36,13 +38,9 @@ const EventPage: React.FC<EventPageProps> = (p: EventPageProps) => {
 
 	return (
 		<>
-			{formMode === "view" ? (
-				<ViewEvent savedEvent={savedEvent} />
-			) : (
-				<CTFFormProvider formMode={formMode} formSection={p.location.state?.formSection}>
-					<EventForm savedEvent={savedEvent} />
-				</CTFFormProvider>
-			)}
+			<CTFFormProvider formMode={formMode} formSection={p.location.state?.formSection ?? DEFAULT_SECTION}>
+				{formMode === "view" ? <ViewEvent savedEvent={savedEvent} /> : <EventForm savedEvent={savedEvent} />}
+			</CTFFormProvider>
 		</>
 	)
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -70,7 +70,7 @@ const IndexPage: React.FC = () => {
 		return sortOnLoad([...formattedEvents])
 	}
 	const [sortedEvents, setSortedEvents] = useState<EventFormData[]>(initialEvents())
-	const [sortOption, setSortOption] = useState("")
+	const [sortOption, setSortOption] = useState("-Last Updated")
 	const [searchTerm, setSearchTerm] = useState("")
 	const [hideInactive, setHideInactive] = useState(true)
 	//Pagination states

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,8 @@
 import React, { useState } from "react"
 import moment from "moment"
-import { navigate } from "gatsby"
 
 import Pagination from "@material-ui/lab/Pagination"
-import { H1, C1_DATE_FORMAT as DateFormat, Button } from "@c1ds/components"
+import { H1, C1_DATE_FORMAT as DateFormat } from "@c1ds/components"
 import { Flex } from "@chakra-ui/core"
 
 import Layout from "../components/Layout"
@@ -41,8 +40,9 @@ const IndexPage: React.FC = () => {
 		let eventList = savedEvents
 		if (!savedEvents) {
 			const formattedEvents = eventsJSON.map(event => {
+				const { eventLklDtoList, ...eventSummaryData } = event
 				const eventWithDate: EventFormData = {
-					...event,
+					...eventSummaryData,
 					eventStartDate: event.eventStartDate ? moment(event.eventStartDate, DateFormat).toDate() : undefined,
 					eventEndDate: event.eventEndDate ? moment(event.eventEndDate, DateFormat).toDate() : undefined,
 					evacDepAuthDate: event.evacDepAuthDate ? moment(event.evacDepAuthDate, DateFormat).toDate() : undefined,


### PR DESCRIPTION
Event List
1.1 "Sort by" dropdown highlights currently sorted field when opened

Create Event
1.2 Save success banner does not display when event creation is completed

View Event
1.3 Active/Inactive badge replaced with a Status field/text in the Event Overview tab's Event Details section
1.4 Impacted Area renamed to Impacted posts in Event Overview tab
1.5 Event Overview tab - Impacted Area section description is "Which Consular Posts are impacted by this event? For a list of posts, consult the FAM."

Edit Event
1.6 Save success banner does not display when event creation is completed
1.7 Navigation breadcrumb displays at the top of the page
1.8 Page title is "Edit Event Details"
1.9 Edit Event - Event Details section: Page description is "Edit the basic information related to the developing crisis."

General
1.10 Data Loss Warning - "Stay" button displays no blue background/fill