### PR TITLE
Talking points

### DIFF
--- a/src/components/FormSections/TalkingPointsDetails.tsx
+++ b/src/components/FormSections/TalkingPointsDetails.tsx
@@ -1,9 +1,8 @@
 import React, { useRef, useState } from "react"
-import { useFormContext, Controller } from "react-hook-form"
+import { Controller } from "react-hook-form"
 import { Box, Divider, VisuallyHidden, Flex, useDisclosure } from "@chakra-ui/core"
 import { FormInput, H4, P, FileUploader, Card, Link, Button, 
     Modal, ModalHeader, ModalCloseButton} from "@c1ds/components"
-// import chargeSample from '../../../content/Talking_Points_SOP.docx'
 
 import { FormSection, useCTFFormContext } from "../Forms/Form"
 import Dropdown from "../Dropdown"
@@ -12,17 +11,16 @@ import DeleteTalkingPointModal from '../Modals/DeleteTalkingPointModal'
 import { MoreVertSharp } from "@material-ui/icons"
 
 const TalkingPointDetails: React.FC = () => {
-    const { setValue } = useFormContext<EventFormData>()
-
     const { isOpen: defaultModalOpen, onOpen: onDefaultModalOpen, onClose: onDefaultModalClose } = useDisclosure()
     const { isOpen: removeModalOpen, onOpen: onRemoveModalOpen, onClose: onRemoveModalClose } = useDisclosure()
 
     const [ errorMsg, setErrorMsg ] = useState<string>('')
-    const [ talkingPoint, setTalkingPoint ] = useState<TalkingPoint|null>(null)
+    const [ isTPExist, setIsTPExist ] = useState<boolean>(false)
 
+    // Ref to the hidden input type="file"
 	const talkingPointRef = useRef<HTMLInputElement>(null)
 
-    const { isCreate, isView } = useCTFFormContext()
+    const { isCreate } = useCTFFormContext()
 
     const options = [
 		{
@@ -41,7 +39,6 @@ const TalkingPointDetails: React.FC = () => {
 		},
     ]
     
-    // 1.6 The system displays appropriate error message when the file size exceeding 5MB
     const maxSize = 1024 * 1024 * 5
     const acceptedFileFormats = [
         "text/plain",
@@ -51,7 +48,7 @@ const TalkingPointDetails: React.FC = () => {
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
     ]
 
-    const setFileInForm = (file : File, onChange : (tp : TalkingPoint) => void) => {
+    const setFileInForm = (file : File, onChange : (tp : TalkingPoint | undefined) => void) => {
         const reader = new FileReader()
         reader.readAsDataURL(file)
         reader.onload = () => {
@@ -62,17 +59,14 @@ const TalkingPointDetails: React.FC = () => {
                 fileDataURL : reader.result
             }
             onChange(talkingPoint)
-            setTalkingPoint(talkingPoint)
+            setIsTPExist(true)
         }
     }
     
 	return (
-        // 1.2         The user can see the following fields on the Add New Talking Points section
-        //       • Default Talking Points - hyperlink
-        //       • Upload File Area: [Drop/Browse]
 		<FormSection title="Talking Points" showDivider={isCreate} >
             <Box gridColumn={{ base: "1 / -1" }} >
-                {talkingPoint ? 
+                {isTPExist ? 
                     <P>You have added talking points to this event. The default talking points have been removed.</P>
                 :
                     <P>If Talking Points aren&apos;t 
@@ -108,140 +102,125 @@ const TalkingPointDetails: React.FC = () => {
                 </Modal>
             </Box>
             
-            {/* Hidden File input field */}
-            <Controller
-                name="talkingPoints"
-                render={({onChange}) => (
-                    /* @ts-ignore */
-                    <VisuallyHidden as="input" type="file" ref={talkingPointRef} 
-                        name="talkingPoints"
-                        aria-hidden={true}
-                        tabIndex={-1}
-                        accept={acceptedFileFormats.join()}
-                        onChange={(e : React.FormEvent<HTMLInputElement>) => {
-                            // @ts-ignore
-                            const uploadFile = e.target.files[0]
-                            console.log(uploadFile)
-
-                            if (!acceptedFileFormats.includes(uploadFile.type)){
-                                setErrorMsg("File type must be one of .doc, .docx, .txt, .rtf, .pdf")
-                            } else if (uploadFile.size > maxSize){
-                                setErrorMsg("File is larger than 5242880 bytes")
-                            } else{
-                                setFileInForm(uploadFile, onChange)
-                            }
-                            
-                        }}/>     
-                )}
-            />
-            
-            {/* Reason for using ternary is that there is no reset function in File Uploader Thus,
-            need to re-render it when user removes the talking point */}
             <Box gridColumn={{ base: "1 / -1", lg: "span 9" }}>
-                <FormInput labelText="Attachments" labelId="talkingPointsLabel">
-                {talkingPoint ?
-                    (
-                    // 1.7   The system displays a Talking Points "card" after a successful upload with the file name displayed on the card.
-                    // 1.7.1 The user can see the following fields on the Talking Point card
-                    //       •  Hyperlinked Talking Points file name
-                    //       •  [Remove]
-                    // 1.7.2 The user can click on the hyperlinked Talking Points filename to download the file and view the content.
-                    // 1.7.3 The system displays the Upload File Area/Default Talking Points after the user removes the uploaded Talking Points
-                    <Box mt={8}>
-                        <Card id={`talkingPointItem`} >
-                            <Flex 
-                                w="full" 
-                                my={{ base: "-8px", sm: "-12px" }} 
-                                flexDir={{ base: "row" }}>
-                                <Flex flexGrow={1} justifyContent="flex-start">
-                                    <Link 
-                                        href={`${talkingPoint.fileDataURL}`} 
-                                        download={talkingPoint.fileName}>
-                                        {talkingPoint.fileName}
-                                    </Link>
-                                </Flex>
-                                {/* Additional Talking Points actions Replace and Remove */}
-                                <Flex display={{ base: "none", md:"flex" }} flexGrow={1} justifyContent="flex-end">
-                                    <Link href="" aria-label="Replace" onClick={(e)=> {
-                                        e.preventDefault()
-                                        talkingPointRef.current?.click()} 
-                                    }>
-                                        Replace
-                                    </Link>
-                                    <Box mx={24} >
-                                        <Divider position="absolute" 
-                                        h={{base:16, sm: 16 }}
-                                        top={{base:-12, sm: -16}} 
-                                        orientation="vertical" 
-                                        color="silver" />
-                                    </Box>
-                                    <Link href="" aria-label="Remove" onClick={(e)=> {
-                                        e.preventDefault()
-                                        onRemoveModalOpen()} 
-                                    }>
-                                        Remove
-                                    </Link>
-                                    <DeleteTalkingPointModal
-                                        isOpen={removeModalOpen}
-                                        onCancel={onRemoveModalClose}
-                                        onConfirm={() => {
-                                            setTalkingPoint(null)
-                                            setValue("talkingPoints", {})
-                                            onRemoveModalClose()
-                                        }}
-                                    />
-                                </Flex>
-                                <Flex display={{ md: "none" }} justifyContent="flex-end">
-                                    <Box position="relative" right={{ base: "-12px" }}>
-                                        <Dropdown
-                                            options={options}
-                                            borderedRows={true}
-                                            width="10rem"
-                                            label={`Additional actions for ${talkingPoint.fileName}`}>
-                                            <Box as={MoreVertSharp} color="clickable" />
-                                        </Dropdown>
-                                    </Box>
-                                </Flex>
-                            </Flex>
-                        </Card>
-                        { errorMsg !== '' && <P color="error">{errorMsg}</P>}
-                    </Box>
-                    ) :
-                    // 1.3 (Drop function) The user can drag a file from user’s local desktop and drop it into the [Drop/Browse] area to upload the file
-                    // 1.4 (Browse Function) The user can click [Drop/Browse] area to launch an interface (e.g. File Explorer) which allows the user to identify the proper document to be uploaded.
-                    // 1.5 The system displays appropriate error message when the selected file is in the unacceptable format.
-                    //     · Valid file formats are - .doc, docx, .txt, .rtf, .pdf
-                    <Controller
-                        name="talkingPoints"
-                        render={({onChange}) => (
-                            <FileUploader
-                                id="talkingPoints"
-                                aria-labelledby="talkingPoints"
-                                name="talkingPoints"
-                                maxSizeBytes={maxSize}
-                                allowedFileTypes={[
-                                    ".doc",
-                                    ".docx",
-                                    ".txt",
-                                    ".rtf",
-                                    ".pdf",
-                                ]}
-                                onDrop={(_, files) => {      
-                                    setFileInForm(files[0], onChange)
-                                    setErrorMsg('')
-                                }}
-                                handleRejectedFiles={(_, files) => {
-                                    setErrorMsg(files[0].errors[0])
-                                }} 
-                                errorMessage={errorMsg}
-                            />
-                        )}
-                    />
-                }
-                </FormInput>
+                <Controller
+                    name="talkingPoints"
+                    render={({onChange, value}) => {
+                        // Check if Talking Point value exists
+                        setIsTPExist(value ? true : false)
+                        return (
+                            <FormInput labelText="Attachments" labelId="talkingPointsLabel">
+                                {value ?
+                                // Talking Point Card
+                                <Box mt={8}>
+                                    <Card id={`talkingPointItem`} >
+                                        <VisuallyHidden 
+                                            as="input" 
+                                            // @ts-ignore
+                                            type="file" 
+                                            ref={talkingPointRef} 
+                                            name="talkingPoints"
+                                            aria-hidden={true}
+                                            tabIndex={-1}
+                                            accept={acceptedFileFormats.join()}
+                                            onChange={(e : React.FormEvent<HTMLInputElement>) => {
+                                                // @ts-ignore
+                                                const uploadFile = e.target.files[0]
+                                                if (!acceptedFileFormats.includes(uploadFile.type)){
+                                                    setErrorMsg("File type must be one of .doc, .docx, .txt, .rtf, .pdf")
+                                                } else if (uploadFile.size > maxSize){
+                                                    setErrorMsg("File is larger than 5242880 bytes")
+                                                } else{
+                                                    setErrorMsg('')
+                                                    setFileInForm(uploadFile, onChange)
+                                                }
+                                                
+                                            }}/>    
+                                        <Flex 
+                                            w="full" 
+                                            my={{ base: "-8px", sm: "-12px" }} 
+                                            flexDir={{ base: "row" }}>
+                                            <Flex flexGrow={1} justifyContent="flex-start">
+                                                <Link 
+                                                    href={`${value.fileDataURL}`} 
+                                                    download={value.fileName}>
+                                                    {value.fileName}
+                                                </Link>
+                                            </Flex>
+                                            {/* Additional Talking Points actions Replace and Remove */}
+                                            <Flex display={{ base: "none", md:"flex" }} flexGrow={1} justifyContent="flex-end">
+                                                <Link href="" aria-label="Replace" onClick={(e)=> {
+                                                    e.preventDefault()
+                                                    talkingPointRef.current?.click()} 
+                                                }>
+                                                    Replace
+                                                    </Link>
+                                                <Box mx={24} >
+                                                    <Divider position="absolute" 
+                                                    h={{base:16, sm: 16 }}
+                                                    top={{base:-12, sm: -16}} 
+                                                    orientation="vertical" 
+                                                    color="silver" />
+                                                </Box>
+                                                <Link href="" aria-label="Remove" onClick={(e)=> {
+                                                    e.preventDefault()
+                                                    onRemoveModalOpen()
+                                                }}>
+                                                    Remove
+                                                    </Link>
+                                                <DeleteTalkingPointModal
+                                                    isOpen={removeModalOpen}
+                                                    onCancel={onRemoveModalClose}
+                                                    onConfirm={() => {
+                                                        setIsTPExist(false)
+                                                        onChange(undefined)
+                                                        onRemoveModalClose()
+                                                    }}
+                                                />
+                                            </Flex>
+                                            <Flex display={{ md: "none" }} justifyContent="flex-end">
+                                                <Box position="relative" right={{ base: "-12px" }}>
+                                                    <Dropdown
+                                                        options={options}
+                                                        borderedRows={true}
+                                                        width="10rem"
+                                                        label={`Additional actions for ${value.fileName}`}>
+                                                        <Box as={MoreVertSharp} color="clickable" />
+                                                    </Dropdown>
+                                                </Box>
+                                            </Flex>
+                                        </Flex>
+                                    </Card>
+                                    { errorMsg !== '' && <P color="error">{errorMsg}</P>}
+                                </Box>
+                                :
+                                <FileUploader
+                                    id="talkingPoints"
+                                    aria-labelledby="talkingPoints"
+                                    name="talkingPoints"
+                                    maxSizeBytes={maxSize}
+                                    allowedFileTypes={[
+                                        ".doc",
+                                        ".docx",
+                                        ".txt",
+                                        ".rtf",
+                                        ".pdf",
+                                    ]}
+                                    onDrop={(_, files) => {      
+                                        setFileInForm(files[0], onChange)
+                                        setErrorMsg('')
+                                    }}
+                                    handleRejectedFiles={(_, files) => {
+                                        setErrorMsg(files[0].errors[0])
+                                    }} 
+                                    errorMessage={errorMsg}
+                                />
+                                }
+                            </FormInput>
+                        )
+                    }}
+                />
             </Box>
-            
-            
 		</FormSection>
 	)
 }

--- a/src/components/Forms/EventForm.tsx
+++ b/src/components/Forms/EventForm.tsx
@@ -123,7 +123,7 @@ const EventForm: React.FC<EventFormProps> = (p: EventFormProps) => {
 
 					{(isCreate || (isEdit && formSection === "overview")) && <EventDetails hideTitle={isEdit} />}
 
-					{(isCreate || (isEdit && formSection === "talkingPoints")) && <TalkingPointsDetails />}
+					{(isCreate || (isEdit && formSection === "overview")) && <TalkingPointsDetails />}
 
 					{(isCreate || (isEdit && formSection === "evacuation")) && <EvacDetails />}
 

--- a/src/components/Forms/Form.tsx
+++ b/src/components/Forms/Form.tsx
@@ -61,7 +61,7 @@ export const FormSection: React.FC<FormSectionProps> = p => (
 	</Grid>
 )
 
-export type EventFormSections = "overview" | "locations" | "evacuation" | "attachments" | "talkingPoints"
+export type EventFormSections = "overview" | "locations" | "evacuation" | "attachments" 
 
 interface FormContextProps {
 	/**


### PR DESCRIPTION
- [x] 1.1         The user can access the Edit Talking Points screen when Editing an Event
- [x] 1.2         The system displays the "current" Talking Points card from previously uploaded file
- [x] 1.3         The user can see the following fields on the Talking Point card
                 •  Hyperlinked Talking Points file name (e.g. Default Talking Points or uploaded filename)
                 •  [Remove]
- [x] 1.4        The user can click on the hyperlinked Talking Points filename to download the file and view the content.
- [x] 1.5        The user can remove the "current" Talking Points file
- [x] 1.6        The system displays the "Upload File Area: [Drop/Browse]" to allow user to upload a new Talking Points.
- [x] 1.7        (Drop function) The user can drag a file from user’s local desktop and drop it into the [Drop/Browse] area to upload the file
- [x] 1.8        (Browse Function) The user can click [Drop/Browse] area to launch an interface (e.g. File Explorer) which allows the user to identify the proper document to be uploaded.
- [x] 1.9        The system displays appropriate error message when the selected file is in the unacceptable format.
                ·         Valid file formats are - .doc, docx, .txt, .rtf, .pdf
- [x] 1.10      The system displays appropriate error message when the file size exceeding 5MB
**Note: There still is an issue with local storage**
- [x] 1.11      The system only allows one Talking Points file to be uploaded.

Note: Confirm with Katherine that **_the talking point card on View Event should NOT have Replace/Remove_**