### PR TITLE
Empty Talking Points confirmation modal

### DIFF
--- a/src/components/FormSections/TalkingPointsDetails.tsx
+++ b/src/components/FormSections/TalkingPointsDetails.tsx
@@ -1,9 +1,9 @@
 import React, { useRef, useState } from "react"
 import { Controller } from "react-hook-form"
 import { Box, Divider, VisuallyHidden, Flex, useDisclosure } from "@chakra-ui/core"
-import { FormInput, H4, P, FileUploader, Card, Link, Button, 
-    Modal, ModalHeader, ModalCloseButton} from "@c1ds/components"
+import { FormInput, P, FileUploader, Card, Link } from "@c1ds/components"
 
+import { TALKINGPOINTSOPURL } from "../PageSections/EventOverviewTab"
 import { FormSection, useCTFFormContext } from "../Forms/Form"
 import Dropdown from "../Dropdown"
 import DeleteFileModal from "../Modals/DeleteFileModal"
@@ -11,7 +11,6 @@ import DeleteFileModal from "../Modals/DeleteFileModal"
 import { MoreVertSharp } from "@material-ui/icons"
 
 const TalkingPointDetails: React.FC = () => {
-    const { isOpen: defaultModalOpen, onOpen: onDefaultModalOpen, onClose: onDefaultModalClose } = useDisclosure()
     const { isOpen: removeModalOpen, onOpen: onRemoveModalOpen, onClose: onRemoveModalClose } = useDisclosure()
 
     const [ errorMsg, setErrorMsg ] = useState<string>('')
@@ -69,37 +68,10 @@ const TalkingPointDetails: React.FC = () => {
                 {isTPExist ? 
                     <P>You have added talking points to this event. The default talking points have been removed.</P>
                 :
-                    <P>If Talking Points aren&apos;t 
-                    available, <Link onClick={onDefaultModalOpen}>default Talking Points</Link> will 
-                    be presented based on the Event Type.</P>
+                <P>If the approved talking points aren&apos;t 
+                available, <Link href={TALKINGPOINTSOPURL}>pre-determined talking points</Link> will 
+                automatically attached to this event</P>
                 }
-                <Modal 
-                    isOpen={defaultModalOpen} 
-                    onClose={onDefaultModalClose} 
-                    isCentered={true} 
-                    size="lg">
-                    <ModalHeader>
-                        <H4>Default Talking Points</H4>
-                    </ModalHeader>
-                    <ModalCloseButton />
-                    <Box mt={{ base: "-92px", sm: "-108px" ,md: "-144px" }} gridColumn={{ base: "1 / -1" }} >
-                        <P>
-                            We are aware of the event at hand. We are monitoring the event closely 
-                            and will update you with any new information that comes forth during 
-                            this unprecedented time. We thank you for your understanding and ultimately 
-                            for your cooperation.
-                        </P>
-                    </Box>
-                        <Flex 
-                            justifyContent="center" 
-                            alignItems="flex-end"
-                            gridColumn={{ base: "1 / -1" }}>
-                            <Button buttonType="primary" onClick={onDefaultModalClose}>
-                                Close
-                            </Button>
-
-                        </Flex>
-                </Modal>
             </Box>
             
             <Box gridColumn={{ base: "1 / -1", lg: "span 9" }}>

--- a/src/components/FormSections/TalkingPointsDetails.tsx
+++ b/src/components/FormSections/TalkingPointsDetails.tsx
@@ -70,7 +70,7 @@ const TalkingPointDetails: React.FC = () => {
                 :
                 <P>If the approved talking points aren&apos;t 
                 available, <Link href={TALKINGPOINTSOPURL}>pre-determined talking points</Link> will 
-                automatically attached to this event</P>
+                be attached to this event.</P>
                 }
             </Box>
             

--- a/src/components/Forms/EventForm.tsx
+++ b/src/components/Forms/EventForm.tsx
@@ -85,7 +85,6 @@ const EventForm: React.FC<EventFormProps> = (p: EventFormProps) => {
 	}, [updateSavedForm, isEdit, onSaveOpen, onSaveClose, getValues, formSection])
 
 	const onSubmit = (data: EventFormData, skipNavigate = false) => {
-		console.log(data)
 		data.lastUpdatedDateTime = new Date()
 		data.impactedPosts = data.impactedPosts ?? []
 		data.attachments = []

--- a/src/components/Modals/ConfirmTalkingPointModal.tsx
+++ b/src/components/Modals/ConfirmTalkingPointModal.tsx
@@ -1,0 +1,34 @@
+import React from "react"
+import { H4, P, Button, Modal, ModalBody, ModalFooter, ModalHeader, ModalCloseButton, LinkButton } from "@c1ds/components"
+import { Flex, Box } from "@chakra-ui/core"
+
+interface ConfirmTalkingPointModalProps {
+	isOpen: boolean
+	onClose: React.ComponentProps<typeof Modal>["onClose"]
+	onConfirm: () => void
+}
+
+export const ConfirmTalkingPointModal: React.FC<ConfirmTalkingPointModalProps> = (p: ConfirmTalkingPointModalProps) => (
+	<Modal isOpen={p.isOpen} onClose={p.onClose} isCentered={true} size="sm">
+		<ModalHeader>
+			<H4>Empty Talking Point</H4>
+		</ModalHeader>
+		<ModalCloseButton />
+		<ModalBody>
+			<P>The event is saving with the pre-determined Talking Points, Would you like to continue?</P>
+		</ModalBody>
+
+		<ModalFooter>
+			<Flex align="center">
+				<Box marginRight="20">
+					<LinkButton onClick={p.onClose}>
+                    Cancel
+                    </LinkButton>
+				</Box>
+				<Button size="sm" onClick={p.onConfirm} buttonType="secondary">
+                    Continue
+				</Button>
+			</Flex>
+		</ModalFooter>
+	</Modal>
+)

--- a/src/components/Modals/ConfirmTalkingPointModal.tsx
+++ b/src/components/Modals/ConfirmTalkingPointModal.tsx
@@ -15,7 +15,7 @@ export const ConfirmTalkingPointModal: React.FC<ConfirmTalkingPointModalProps> =
 		</ModalHeader>
 		<ModalCloseButton />
 		<ModalBody>
-			<P>The event is saving with the pre-determined Talking Points, Would you like to continue?</P>
+			<P>The event is saving with the pre-determined Talking Points. Would you like to continue?</P>
 		</ModalBody>
 
 		<ModalFooter>

--- a/src/components/PageSections/EventOverviewTab.tsx
+++ b/src/components/PageSections/EventOverviewTab.tsx
@@ -9,7 +9,7 @@ import eventTypes from "../../../content/eventTypes.json"
 import evacStatuses from "../../../content/evacuationStatuses.json"
 import { EventPageState } from "../../pages/event"
 
-const TALKINGPOINTSOPURL = 'https://clmccm-usdos.msappproxy.net/ccm/resource/itemName/com.ibm.team.workitem.Attachment/13685'
+export const TALKINGPOINTSOPURL = 'https://clmccm-usdos.msappproxy.net/ccm/resource/itemName/com.ibm.team.workitem.Attachment/13685'
 //TODO: Use exported type
 interface Option {
 	label: string


### PR DESCRIPTION
On Creating an event:
- [x] 1. The user can use the "pre-determined" Talking Points when creating an event by not uploading a new Talking Points file.
- [x] 2. The user sees the confirmation message on Pre-determined Talking Points is being used when saving the event.

On Editing an event:
- [x] 3. The user can view the "current" Talking Points card when editing an event
- [x] 3.1     The system displays the "current" Talking Points card from previously uploaded file
- [x] 3.2     The user can see the following fields on the Talking Point card
               •  Hyperlinked Talking Points file name (e.g. Default Talking Points or uploaded filename)
               •  [Remove]
- [x] 4.     The user can click on the [Remove] next to the Talking Points filename to delete the "current" Talking Points (note: the current Talking Points can be the Pre-determined or new uploaded file)
- [x] 5.   The system uses pre-determined Talking Points when the user removed the "current" Talking Points without uploading a new file.
- [x] 5.1  The user sees the confirmation message on Pre-determined Talking Points is being used when saving the event.
