### PR TITLE
Updating saved form tracking and updating

### DIFF
--- a/src/components/AttachmentCard.tsx
+++ b/src/components/AttachmentCard.tsx
@@ -2,28 +2,28 @@ import React, { useRef } from "react"
 import { Box, useDisclosure, Flex, Divider, VisuallyHidden } from "@chakra-ui/core"
 import { Link, Card } from "@c1ds/components"
 import { MoreVertSharp } from "@material-ui/icons"
-import { useSavedForm } from "./Utility/formHelpers"
 import DeleteFileModal from "./Modals/DeleteFileModal"
 import Dropdown from "./Dropdown"
+import { useCTFFormContextWSavedForm } from "./Forms/Form"
 
 interface AttachmentCardProp {
-    attachmentDto: AttachmentDto
-    eventData: EventFormData
-    setAttachmentDtoList: React.Dispatch<React.SetStateAction<AttachmentDto[]>>
-    setEventData: (eventData: EventFormData) => void
-    setErrorMsg: React.Dispatch<React.SetStateAction<string>>
+	attachmentDto: AttachmentDto
+	eventData: EventFormData
+	setAttachmentDtoList: React.Dispatch<React.SetStateAction<AttachmentDto[]>>
+	setErrorMsg: React.Dispatch<React.SetStateAction<string>>
 }
 
 const AttachmentCard: React.FC<AttachmentCardProp> = (p: AttachmentCardProp) => {
-    const { attachmentDto, eventData, setAttachmentDtoList, setEventData, setErrorMsg } = p
-    const { attachments } = eventData
+	const { attachmentDto, eventData, setAttachmentDtoList, setErrorMsg } = p
+	const { attachments } = eventData
 
-    const [savedEvents, updateSavedEvents] = useSavedForm<EventFormData[]>("ctfForms", "events")
-    const { isOpen: isAttachmentOpen, onOpen: onAttachmentOpen, onClose: onAttachmentClose } = useDisclosure()
+	const { savedForm: savedEvents, updateSavedForm: updateSavedEvents } = useCTFFormContextWSavedForm()
 
-    const attachmentRef = useRef<HTMLInputElement>(null)
+	const { isOpen: isAttachmentOpen, onOpen: onAttachmentOpen, onClose: onAttachmentClose } = useDisclosure()
 
-    // 1.5 The system accepts the following file format of the selected file
+	const attachmentRef = useRef<HTMLInputElement>(null)
+
+	// 1.5 The system accepts the following file format of the selected file
 	// · Image(.jpg, .jpeg, .gif, .png)
 	// · Spreadsheet(.xls, .xlsx)
 	// · Text File(.doc, docx, .txt, .rtf, .pdf)
@@ -38,9 +38,9 @@ const AttachmentCard: React.FC<AttachmentCardProp> = (p: AttachmentCardProp) => 
 		"text/plain",
 		"application/rtf",
 		"application/pdf",
-    ]
-    
-    const cardOptions = [
+	]
+
+	const cardOptions = [
 		{
 			label: "Replace",
 			value: "Replace",
@@ -57,118 +57,116 @@ const AttachmentCard: React.FC<AttachmentCardProp> = (p: AttachmentCardProp) => 
 		},
 	]
 
-    const setFileOnCard = (file: File) => {
-        const reader = new FileReader()
-        reader.readAsDataURL(file)
-        reader.onload = () => {
-            if (eventData && eventData.attachments) {
-                eventData.attachments[eventData.attachments.indexOf(attachmentDto)] = {
-                    fileName: file.name,
-                    fileSize: file.size,
-                    fileMimeType: file.type,
-                    fileDataURL: reader.result,
-                }
-                setAttachmentDtoList([...eventData.attachments])
-                setEventData(eventData)
-                const savedEventIndex = savedEvents.findIndex((evt: EventFormData) => evt.eventId === eventData.eventId)
-                savedEvents.splice(savedEventIndex, 1, eventData)
-                updateSavedEvents(savedEvents)
-            }
-        }
-    }
+	const setFileOnCard = (file: File) => {
+		const reader = new FileReader()
+		reader.readAsDataURL(file)
+		reader.onload = () => {
+			if (eventData && eventData.attachments) {
+				eventData.attachments[eventData.attachments.indexOf(attachmentDto)] = {
+					fileName: file.name,
+					fileSize: file.size,
+					fileMimeType: file.type,
+					fileDataURL: reader.result,
+				}
+				setAttachmentDtoList([...eventData.attachments])
+				const savedEventIndex = savedEvents.findIndex((evt: EventFormData) => evt.eventId === eventData.eventId)
+				savedEvents.splice(savedEventIndex, 1, eventData)
+				updateSavedEvents(savedEvents)
+			}
+		}
+	}
 
-    return (
-        <Box>
-            <Card id="attachmentCard" maxWidth="full">
-                <Flex w="full" my={{ base: "-8px", sm: "-12px" }} flexDir={{ base: "row" }}>
-                    {/* 1.4 The user can see the following information on the Attachment card
+	return (
+		<Box>
+			<Card id="attachmentCard" maxWidth="full">
+				<Flex w="full" my={{ base: "-8px", sm: "-12px" }} flexDir={{ base: "row" }}>
+					{/* 1.4 The user can see the following information on the Attachment card
                 · Filename name (hyperlinked)
                 · [Replace] Function
                 · [Remove] function */}
-                    {/* 1.5 The user can click on the hyperlinked Attachment filename to download the file and view the content. */}
-                    <Flex flexGrow={1} justifyContent="flex-start">
-                        <Link href={`${attachmentDto.fileDataURL}`} download={attachmentDto.fileName}>
-                            {attachmentDto.fileName}
-                        </Link>
-                    </Flex>
-                    <Flex display={{ base: "none", md: "flex" }} flexGrow={1} justifyContent="flex-end">
-                        <Link
-                            onClick={e => {
-                                e.preventDefault()
-                                setErrorMsg("")
-                                attachmentRef.current?.click()
-                            }}>
-                            Replace
-                        </Link>
-                        <Box mx={24}>
-                            <Divider
-                                position="absolute"
-                                h={{ base: 16, sm: 16 }}
-                                top={{ base: -12, sm: -16 }}
-                                orientation="vertical"
-                                color="silver"
-                            />
-                        </Box>
-                        <Link
-                            onClick={e => {
-                                e.preventDefault()
-                                onAttachmentOpen()
-                            }}>
-                            Remove
-                        </Link>
+					{/* 1.5 The user can click on the hyperlinked Attachment filename to download the file and view the content. */}
+					<Flex flexGrow={1} justifyContent="flex-start">
+						<Link href={`${attachmentDto.fileDataURL}`} download={attachmentDto.fileName}>
+							{attachmentDto.fileName}
+						</Link>
+					</Flex>
+					<Flex display={{ base: "none", md: "flex" }} flexGrow={1} justifyContent="flex-end">
+						<Link
+							onClick={e => {
+								e.preventDefault()
+								setErrorMsg("")
+								attachmentRef.current?.click()
+							}}>
+							Replace
+						</Link>
+						<Box mx={24}>
+							<Divider
+								position="absolute"
+								h={{ base: 16, sm: 16 }}
+								top={{ base: -12, sm: -16 }}
+								orientation="vertical"
+								color="silver"
+							/>
+						</Box>
+						<Link
+							onClick={e => {
+								e.preventDefault()
+								onAttachmentOpen()
+							}}>
+							Remove
+						</Link>
 
-                        <DeleteFileModal
-                            type="attachment"
-                            isOpen={isAttachmentOpen}
-                            onCancel={onAttachmentClose}
-                            onConfirm={() => {
-                                const selectedIndex = attachments?.indexOf(attachmentDto)
-                                eventData.attachments = attachments?.filter((att, index) => index !== selectedIndex)
-                                setAttachmentDtoList(eventData.attachments ?? [])
-                                setEventData(eventData)
-                                const savedEventIndex = savedEvents.findIndex(
-                                    (evt: EventFormData) => evt.eventId === eventData.eventId
-                                )
-                                savedEvents.splice(savedEventIndex, 1, eventData)
-                                updateSavedEvents(savedEvents)
-                                onAttachmentClose()
-                            }}
-                        />
-                    </Flex>
+						<DeleteFileModal
+							type="attachment"
+							isOpen={isAttachmentOpen}
+							onCancel={onAttachmentClose}
+							onConfirm={() => {
+								const selectedIndex = attachments?.indexOf(attachmentDto)
+								eventData.attachments = attachments?.filter((att, index) => index !== selectedIndex)
+								setAttachmentDtoList(eventData.attachments ?? [])
+								const savedEventIndex = savedEvents.findIndex(
+									(evt: EventFormData) => evt.eventId === eventData.eventId
+								)
+								savedEvents.splice(savedEventIndex, 1, eventData)
+								updateSavedEvents(savedEvents)
+								onAttachmentClose()
+							}}
+						/>
+					</Flex>
 
-                    <Flex display={{ md: "none" }} justifyContent="flex-end">
-                        <Box position="relative" right={{ base: "-12px" }}>
-                            <Dropdown
-                                options={cardOptions}
-                                borderedRows={true}
-                                width="10rem"
-                                label={`Additional actions for ${attachmentDto.fileName}`}>
-                                <Box as={MoreVertSharp} color="clickable" />
-                            </Dropdown>
-                        </Box>
-                    </Flex>
-                </Flex>
-            </Card>
+					<Flex display={{ md: "none" }} justifyContent="flex-end">
+						<Box position="relative" right={{ base: "-12px" }}>
+							<Dropdown
+								options={cardOptions}
+								borderedRows={true}
+								width="10rem"
+								label={`Additional actions for ${attachmentDto.fileName}`}>
+								<Box as={MoreVertSharp} color="clickable" />
+							</Dropdown>
+						</Box>
+					</Flex>
+				</Flex>
+			</Card>
 
-            <VisuallyHidden
-                as="input"
-                /* @ts-ignore */
-                type="file"
-                ref={attachmentRef}
-                name="talkingPoints"
-                aria-hidden={true}
-                tabIndex={-1}
-                accept={acceptedFileFormats.join()}
-                onChange={(e: React.FormEvent<HTMLInputElement>) => {
-                    // @ts-ignore
-                    const fileToReplace = e.target.files[0]
-                    !acceptedFileFormats.includes(fileToReplace.type)
-                        ? setErrorMsg("File type must be one of .jpg .jpeg .gif .png .xls .xlsx .doc .docx .txt .rtf .pdf")
-                        : setFileOnCard(fileToReplace)
-                }}
-            />
-        </Box>
-    )
+			<VisuallyHidden
+				as="input"
+				/* @ts-ignore */
+				type="file"
+				ref={attachmentRef}
+				name="talkingPoints"
+				aria-hidden={true}
+				tabIndex={-1}
+				accept={acceptedFileFormats.join()}
+				onChange={(e: React.FormEvent<HTMLInputElement>) => {
+					// @ts-ignore
+					const fileToReplace = e.target.files[0]
+					!acceptedFileFormats.includes(fileToReplace.type)
+						? setErrorMsg("File type must be one of .jpg .jpeg .gif .png .xls .xlsx .doc .docx .txt .rtf .pdf")
+						: setFileOnCard(fileToReplace)
+				}}
+			/>
+		</Box>
+	)
 }
 
 export default AttachmentCard

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -9,7 +9,7 @@ const MotionPseudoBox = motion.custom<Omit<PseudoBoxProps, OmittedBoxProps>>(Pse
 
 export type OptionType = "primary" | "error"
 
-export type DropdownClick = (label: string, value: string) => void
+export type DropdownClick = (value: string, label: string) => void
 
 export interface DropdownOptions {
 	label: string

--- a/src/components/PageSections/EventAttachmentsTab.tsx
+++ b/src/components/PageSections/EventAttachmentsTab.tsx
@@ -1,19 +1,18 @@
 import React, { useState } from "react"
 import { Box, Grid, Flex } from "@chakra-ui/core"
 import { FinePrint, P, H3, FileUploader } from "@c1ds/components"
-import { useSavedForm } from "../Utility/formHelpers"
 import AttachmentCard from "../AttachmentCard"
+import { useCTFFormContextWSavedForm } from "../Forms/Form"
 
 interface AttachmentTabProps {
 	eventData: EventFormData
-	setEventData: (eventData: EventFormData) => void
 }
 
 export const AttachmentsTab: React.FC<AttachmentTabProps> = (p: AttachmentTabProps) => {
-	const { eventData, setEventData } = p
+	const { eventData } = p
 	const { attachments } = eventData
 
-	const [savedEvents, updateSavedEvents] = useSavedForm<EventFormData[]>("ctfForms", "events")
+	const { savedForm: savedEvents, updateSavedForm: updateSavedEvents } = useCTFFormContextWSavedForm()
 
 	// 1.6 The system displays appropriate error message when the selected file is in the unacceptable format.
 	// 1.7 The system displays appropriate error message when the file size exceeding 5MB
@@ -23,7 +22,7 @@ export const AttachmentsTab: React.FC<AttachmentTabProps> = (p: AttachmentTabPro
 
 	const maxSizeBytes = 1024 * 1024 * 5
 	const acceptedFileExtensions = [".jpg", ".jpeg", ".gif", ".png", ".xls", ".xlsx", ".doc", ".docx", ".txt", ".rtf", ".pdf"]
-	
+
 	return (
 		<>
 			{/*1.1 The user can access the Attachment screen from Edit Event option.*/}
@@ -71,7 +70,6 @@ export const AttachmentsTab: React.FC<AttachmentTabProps> = (p: AttachmentTabPro
 								}
 								eventData.attachments?.push(attachment)
 								setAttachmentDtoList(eventData.attachments ?? [])
-								setEventData(eventData)
 								const savedEventIndex = savedEvents.findIndex(
 									(evt: EventFormData) => evt.eventId === eventData.eventId
 								)
@@ -94,12 +92,12 @@ export const AttachmentsTab: React.FC<AttachmentTabProps> = (p: AttachmentTabPro
 				{attachmentDtoList.map((value: AttachmentDto, index: number) => {
 					return (
 						<Box key={index} gridColumn="1 / -1">
-							<AttachmentCard 
+							<AttachmentCard
 								eventData={eventData}
-								setEventData={setEventData}
 								setErrorMsg={setErrorMsg}
 								setAttachmentDtoList={setAttachmentDtoList}
-								attachmentDto={value} />
+								attachmentDto={value}
+							/>
 						</Box>
 					)
 				})}

--- a/src/components/PageSections/EventLklTab.tsx
+++ b/src/components/PageSections/EventLklTab.tsx
@@ -45,7 +45,11 @@ export const LastKnownLocationTab: React.FC<LastKnownLocationTabProps> = (p: Las
 
 	const sortByText = sortOption[0] === "-" ? sortOption.substring(1, sortOption.length) : sortOption
 
-	// Update Location list when saved data updates
+	/**
+	 * Re-sort Location list when:
+	 * Sort option changes (including sort direction)
+	 * Saved event updates (ex. Event Location is deactivated)
+	 */
 	useEffect(() => {
 		const savedEvent = savedEvents.find(event => event.eventId === eventData.eventId)
 		const savedLklDtoList = savedEvent?.eventLklDtoList ?? []

--- a/src/components/PageSections/EventLklTab.tsx
+++ b/src/components/PageSections/EventLklTab.tsx
@@ -1,18 +1,16 @@
-import React, { useEffect, useState, useCallback } from "react"
+import React, { useEffect, useState } from "react"
 import { navigate } from "gatsby"
 import moment from "moment"
 
-import { Flex, Box, Grid, PseudoBox, Button as ChakraButton } from "@chakra-ui/core"
+import { Flex, Box, Grid, Button as ChakraButton } from "@chakra-ui/core"
 import { P, H3, LinkButton, IconAlignment, Link } from "@c1ds/components"
 
 import LKLCard from "../LKLCard"
 import SortLKLFilter from "../SortLKLFilter"
 import HideInactiveButton from "../HideInactiveButton"
-import Dropdown, { DropdownOptions, DropdownClick } from "../Dropdown"
 
 import Pagination from "@material-ui/lab/Pagination"
-import { AddSharp, ArrowDropUpSharp, ArrowDropDownSharp } from "@material-ui/icons"
-import { EventPageState } from "../../pages/event"
+import { AddSharp } from "@material-ui/icons"
 import { AddLocationPageState } from "../../pages/addLocation"
 import { EventLocationTabMapIcon } from "../Icons/icons"
 import { useCTFFormContextWSavedForm } from "../Forms/Form"

--- a/src/components/PageSections/EventOverviewTab.tsx
+++ b/src/components/PageSections/EventOverviewTab.tsx
@@ -9,7 +9,8 @@ import eventTypes from "../../../content/eventTypes.json"
 import evacStatuses from "../../../content/evacuationStatuses.json"
 import { EventPageState } from "../../pages/event"
 
-export const TALKINGPOINTSOPURL = 'https://clmccm-usdos.msappproxy.net/ccm/resource/itemName/com.ibm.team.workitem.Attachment/13685'
+export const TALKINGPOINTSOPURL =
+	"https://clmccm-usdos.msappproxy.net/ccm/resource/itemName/com.ibm.team.workitem.Attachment/13685"
 //TODO: Use exported type
 interface Option {
 	label: string
@@ -28,7 +29,7 @@ export const OverviewTab: React.FC<OverviewTabProps> = (p: OverviewTabProps) => 
 	const talkingPoint = eventData.talkingPoints
 	const impactedPosts = eventData.impactedPosts
 
-	const talkingPointFileName = talkingPoint && talkingPoint.fileName ? talkingPoint.fileName : 'Talking Points SOP.docx'
+	const talkingPointFileName = talkingPoint && talkingPoint.fileName ? talkingPoint.fileName : "Talking Points SOP.docx"
 
 	const isActive = !!eventData.activeIndicator
 
@@ -130,22 +131,18 @@ export const OverviewTab: React.FC<OverviewTabProps> = (p: OverviewTabProps) => 
 					<P>Default Talking Points have been added, pending new Talking Points.</P>
 				</Box>
 				<Box gridColumn={{ base: "1 / -1" }} marginTop={{ base: "24", sm: "0", md: "24" }}>
-					<Box mb={{ base: "4px", md: "-12px" }} >
+					<Box mb={{ base: "4px", md: "-12px" }}>
 						<FinePrint color="label">Uploaded file</FinePrint>
 					</Box>
-					{/* <P>{displayData(eventData.eventSummary)}</P> */}
 				</Box>
 				{/* 1.9 The system uses the Default Talking Points (see user story 177855) when no file has been uploaded.
 					1.10 The user has an option to view the content of the Default Talking Points. */}
 				<Box gridColumn="1 / -1">
-					<Card id={`talkingPointItem`} >
-						<Flex 
-							w="full" 
-							my={{ base: "-8px", sm: "-0px" }} 
-							flexDir={{ base: "row" }}>
+					<Card id={`talkingPointItem`}>
+						<Flex w="full" my={{ base: "-8px", sm: "-0px" }} flexDir={{ base: "row" }}>
 							<Flex flexGrow={1} justifyContent="flex-start">
-								<Link 
-									href={talkingPoint ? `${talkingPoint.fileDataURL}` : TALKINGPOINTSOPURL} 
+								<Link
+									href={talkingPoint ? `${talkingPoint.fileDataURL}` : TALKINGPOINTSOPURL}
 									download={talkingPointFileName}>
 									{talkingPointFileName}
 								</Link>
@@ -168,7 +165,7 @@ export const OverviewTab: React.FC<OverviewTabProps> = (p: OverviewTabProps) => 
 				<Box gridColumn="1 / -1">
 					<H3>Impacted Posts</H3>
 				</Box>
-				<Box gridColumn={{ base: "1 / -1"}}>
+				<Box gridColumn={{ base: "1 / -1" }}>
 					<P>
 						<Text color="required" as="span">
 							*&nbsp;
@@ -183,25 +180,25 @@ export const OverviewTab: React.FC<OverviewTabProps> = (p: OverviewTabProps) => 
 						.
 					</P>
 				</Box>
-				<Grid
-                    gridColumn={{ base: "1 / -1"}}
-                    templateRows={{ base: "1fr 1fr"}}
-                    rowGap={{ base: "16px", md: "24px" }}>
-                    {impactedPosts && impactedPosts.map((post : PostDto) => {
-                        return (
-                            <Card id="ctfPost" maxWidth="full" key={`${post.postValue}-${post.countryValue}`}>
-                                <Flex w="full" my={{ base: "-8px", sm: "-12px" }} flexDir={{ base: "row" }}>
-									<Box flexGrow={1}>
-										<Box pb={4}>
-											<FinePrint color="label">{post.countryName}</FinePrint>
+				<Grid gridColumn={{ base: "1 / -1" }} templateRows={{ base: "1fr 1fr" }} rowGap={{ base: "16px", md: "24px" }}>
+					{impactedPosts &&
+						impactedPosts.map((post: PostDto) => {
+							return (
+								<Card id="ctfPost" maxWidth="full" key={`${post.postValue}-${post.countryValue}`}>
+									<Flex w="full" my={{ base: "-8px", sm: "-12px" }} flexDir={{ base: "row" }}>
+										<Box flexGrow={1}>
+											<Box pb={4}>
+												<FinePrint color="label">{post.countryName}</FinePrint>
+											</Box>
+											<P>
+												U.S. Embassy in {post.postLabel}, {post.countryValue}
+											</P>
 										</Box>
-										<P>U.S. Embassy in {post.postLabel}, {post.countryValue}</P>
-									</Box>
-                                </Flex>
-                            </Card>
-                        )
-                    })}
-                </Grid>
+									</Flex>
+								</Card>
+							)
+						})}
+				</Grid>
 			</Grid>
 		</>
 	)

--- a/src/components/SortLKLFilter.tsx
+++ b/src/components/SortLKLFilter.tsx
@@ -1,106 +1,105 @@
 import React from "react"
 
-import Dropdown, { DropdownOptions } from "./Dropdown"
 import { ArrowDropUpSharp, ArrowDropDownSharp } from "@material-ui/icons"
 import { Box, PseudoBox, Flex, useTheme } from "@chakra-ui/core"
+
+import Dropdown, { DropdownOptions, DropdownClick } from "./Dropdown"
 
 type SortFilterProps = {
 	sortByText: string
 	sortOption: string
-	onSortByLklDto: (value: string, label: string) => void
-	onSortByLookUpLklDto: (value: string, label: string) => void
+	onSortSelection: DropdownClick
+	onSortReverse: () => void
 }
 
 /**
  *  SortLKLFilter component for sorting the LKL list based on a filter (ASC/DESC).
  */
-const SortLKLFilter: React.FC<SortFilterProps> = ({ sortByText, sortOption, onSortByLookUpLklDto, onSortByLklDto }: SortFilterProps) => {
+const SortLKLFilter: React.FC<SortFilterProps> = ({
+	sortByText,
+	sortOption,
+	onSortSelection,
+	onSortReverse,
+}: SortFilterProps) => {
 	const theme = useTheme()
 
 	// Sort option labels, values and onClick event handlers. Order is identical to the option menu
 	const options: DropdownOptions[] = [
-		{ label: "Title", value: "lklTitle", onClick: onSortByLookUpLklDto },
-		{ label: "Country", value: "countryCd", onClick: onSortByLookUpLklDto },
-		{ label: "Post", value: "postCd", onClick: onSortByLookUpLklDto },
-		{ label: "Status", value: "activeIndicator", onClick: onSortByLklDto },
-		{ label: "Last Updated", value: "lastUpdatedDateTime", onClick: onSortByLklDto },
+		{ label: "Title", value: "lklTitle", onClick: onSortSelection },
+		{ label: "Country", value: "countryCd", onClick: onSortSelection },
+		{ label: "Post", value: "postCd", onClick: onSortSelection },
+		{ label: "Status", value: "activeIndicator", onClick: onSortSelection },
+		{ label: "Last Updated", value: "lastUpdatedDateTime", onClick: onSortSelection },
 	]
 
 	// Get value of the options based on the labelKey
 	const getOptionsValue = (labelKey: string) => {
 		return options.find(option => option.label === labelKey)?.value ?? ""
-    }
-    
-    const arrowOnClick = () => {
-        const sortBy = options.find((option : DropdownOptions) => option.label === sortByText)
-        sortBy?.onClick ? sortBy.onClick(getOptionsValue(sortByText), 
-        sortOption[0] === "-" ? sortOption.substring(1) : sortOption) : null
-    }
+	}
 
 	return (
 		<>
 			<Box position="relative" marginRight="20">
-                <Flex align="center">
-                    <Dropdown
-                        options={options}
-                        width="150px"
-                        label="Sort events"
-                        menuProps={{
-                            marginTop: "4",
-                            right: -20,
-                        }}
-                        initialSelection={getOptionsValue("Last Updated")}
-                        showSelected>
-                        <Box as="span" fontSize="base" marginRight={2} cursor="pointer">
-                            Sort by
-                        </Box>
-                    </Dropdown>
-                    {sortOption[0] === "-" ? 
-                        <PseudoBox
-                            as="button"
-                            // @ts-ignore
-                            type="button"
-                            display="inline-flex"
-                            alignItems="center"
-                            justifyContent="center"
-                            padding={0}
-                            border="none"
-                            background="none"
-                            size="iconMd"
-                            cursor="pointer"
-                            aria-label={`Sort by ${sortByText} ascending`}
-                            onClick={arrowOnClick}
-                            _focus={{
-                                // @ts-ignore
-                                outline: `1px dashed ${theme.colors.accent}`,
-                            }}>
-                            <Box as={ArrowDropDownSharp} size="icon" transform="scale(2)" color="clickable" />
-                        </PseudoBox>
-                    :
-                        <PseudoBox
-                            as="button"
-                            // @ts-ignore
-                            type="button"
-                            display="inline-flex"
-                            alignItems="center"
-                            justifyContent="center"
-                            padding={0}
-                            border="none"
-                            background="none"
-                            size="iconMd"
-                            cursor="pointer"
-                            aria-label={`Sort by ${sortByText} descending`}
-                            onClick={arrowOnClick}
-                            _focus={{
-                                // @ts-ignore
-                                outline: `1px dashed ${theme.colors.accent}`,
-                            }}>
-                            <Box as={ArrowDropUpSharp} size="icon" transform="scale(2)" color="clickable" />
-                        </PseudoBox>
-                    }
-                </Flex>
+				<Flex align="center">
+					<Dropdown
+						options={options}
+						width="150px"
+						label="Sort events"
+						menuProps={{
+							marginTop: "4",
+							right: -20,
+						}}
+						initialSelection={getOptionsValue("Last Updated")}
+						showSelected>
+						<Box as="span" fontSize="base" marginRight={2} cursor="pointer">
+							Sort by
+						</Box>
+					</Dropdown>
+					{sortOption[0] === "-" ? (
+						<PseudoBox
+							as="button"
+							// @ts-ignore
+							type="button"
+							display="inline-flex"
+							alignItems="center"
+							justifyContent="center"
+							padding={0}
+							border="none"
+							background="none"
+							size="iconMd"
+							cursor="pointer"
+							aria-label={`Sort by ${sortByText} ascending`}
+							onClick={onSortReverse}
+							_focus={{
+								// @ts-ignore
+								outline: `1px dashed ${theme.colors.accent}`,
+							}}>
+							<Box as={ArrowDropDownSharp} size="icon" transform="scale(2)" color="clickable" />
+						</PseudoBox>
+					) : (
+						<PseudoBox
+							as="button"
+							// @ts-ignore
+							type="button"
+							display="inline-flex"
+							alignItems="center"
+							justifyContent="center"
+							padding={0}
+							border="none"
+							background="none"
+							size="iconMd"
+							cursor="pointer"
+							aria-label={`Sort by ${sortByText} descending`}
+							onClick={onSortReverse}
+							_focus={{
+								// @ts-ignore
+								outline: `1px dashed ${theme.colors.accent}`,
+							}}>
+							<Box as={ArrowDropUpSharp} size="icon" transform="scale(2)" color="clickable" />
+						</PseudoBox>
+					)}
+				</Flex>
 			</Box>
-
 		</>
 	)
 }

--- a/src/components/ViewEvent.tsx
+++ b/src/components/ViewEvent.tsx
@@ -23,9 +23,6 @@ const eventTabs: { label: string; value: EventFormSections }[] = [
 const ViewEvent: React.FC<EventFormProps> = (p: EventFormProps) => {
 	const { savedEvent } = p
 	const { formSection } = useCTFFormContext()
-
-	const [currentEventData, setEventData] = useState(savedEvent)
-
 	const eventData: EventFormData = savedEvent ?? { eventId: "", eventTitle: "", managementTypeCode: "", eventTypeId: "" }
 
 	const [selectedTab, setSelectedTab] = useState<EventFormSections | undefined>(formSection)
@@ -39,6 +36,7 @@ const ViewEvent: React.FC<EventFormProps> = (p: EventFormProps) => {
 		e.currentTarget.blur()
 	}
 
+	// Create context with saved form, update saved events and wrap tabs
 	return (
 		<Layout pageTitle="View Event" pageHeading={eventData.eventTitle}>
 			{/* TODO: Remove temp home nav button once Header/Footer integrated */}
@@ -129,11 +127,11 @@ const ViewEvent: React.FC<EventFormProps> = (p: EventFormProps) => {
 					<Divider borderColor="disabledDark" marginY="2" marginX={0} opacity={1} />
 				</Box>
 				{inLkl ? (
-					<LastKnownLocationTab eventData={currentEventData} setEventData={setEventData} />
+					<LastKnownLocationTab eventData={eventData} />
 				) : inEvacuation ? (
 					<EvacDetailsTab eventData={eventData} />
 				) : inAttachments ? (
-					<AttachmentsTab eventData={eventData} setEventData={setEventData} />
+					<AttachmentsTab eventData={eventData} />
 				) : (
 					<OverviewTab eventData={eventData} />
 				)}

--- a/src/pages/event.tsx
+++ b/src/pages/event.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import moment from "moment"
-import { getSavedForm } from "../components/Utility/formHelpers"
+import { useSavedForm } from "../components/Utility/formHelpers"
 import { CTFFormProvider, CTFFormProviderProps } from "../components/Forms/Form"
 import EventForm from "../components/Forms/EventForm"
 import ViewEvent from "../components/ViewEvent"
@@ -21,8 +21,9 @@ const DEFAULT_SECTION: CTFFormProviderProps["formSection"] = "overview"
 
 const EventPage: React.FC<EventPageProps> = (p: EventPageProps) => {
 	let savedEvent: EventFormData | undefined
+	const [savedEvents, updateSavedEvents] = useSavedForm<EventFormData[]>("ctfForms", "events")
+
 	if (p.location?.state?.eventId) {
-		const savedEvents = getSavedForm<Array<EventFormData>>("ctfForms", "events")
 		savedEvent = savedEvents && savedEvents.find((event: EventFormData) => event.eventId === p.location?.state?.eventId)
 		if (savedEvent) {
 			if (savedEvent.evacDepAuthDate) savedEvent.evacDepAuthDate = moment(savedEvent.evacDepAuthDate).toDate()
@@ -38,7 +39,11 @@ const EventPage: React.FC<EventPageProps> = (p: EventPageProps) => {
 
 	return (
 		<>
-			<CTFFormProvider formMode={formMode} formSection={p.location.state?.formSection ?? DEFAULT_SECTION}>
+			<CTFFormProvider
+				formMode={formMode}
+				formSection={p.location.state?.formSection ?? DEFAULT_SECTION}
+				savedForm={savedEvents}
+				updateSavedForm={updateSavedEvents}>
 				{formMode === "view" ? <ViewEvent savedEvent={savedEvent} /> : <EventForm savedEvent={savedEvent} />}
 			</CTFFormProvider>
 		</>


### PR DESCRIPTION
This pull request includes one major change to how we interact with saved events and a few other smaller changes:
- Refactored Event pages/tabs to include saved event form in Form context. This allows all pages to access a common saved form that will re-render any event page/tab when updated.
- Refactored Event Location sorting to manage sorting in `useEffect` hook. A re-sort will automatically be triggered when:
  - The selected sort option changes (including changing sort direction)
  - Saved event updates (ex. Event Location is deactivated)
- General code cleanup

Please review the Event pages/tabs (i.e. Create Event and View Event) to make sure that saving works as expected and updates to saved data are immediately reflected in the UI.