### PR TITLE
Defects update s4

### DIFF
--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -82,7 +82,7 @@ const EventCard: React.FC<EventCardProps> = ({ data, onConfirm }: EventCardProps
 						<FinePrint>{eventType}</FinePrint>
 					</Box>
 					<Box position="relative" right={{ base: "-12px", sm: "-20px", md: "-12px" }}>
-						<Dropdown options={options} borderedRows={true} label={`Additional actions for ${eventTitle}`}>
+						<Dropdown options={options} label={`Additional actions for ${eventTitle}`}>
 							<Box as={MoreVertSharp} color="clickable" />
 						</Dropdown>
 					</Box>

--- a/src/components/FormSections/ImpactedPostsDetails.tsx
+++ b/src/components/FormSections/ImpactedPostsDetails.tsx
@@ -42,9 +42,11 @@ const ImpactedPostsDetails: React.FC<ImpactedPostsProps> = (p: ImpactedPostsProp
 						*&nbsp;
 					</Text>
 					Which Consular Posts are impacted by this event?&nbsp; For a list of posts,{" "}
-					<Link href="http://fam.a.state.sbu/fam/02FAM/02FAM0460.html#M463" target="_blank" rel="noreferrer noopener">
-						consult the FAM
-					</Link>
+					<Box as="span" textDecoration="underline">
+						<Link href="http://fam.a.state.sbu/fam/02FAM/02FAM0460.html#M463" target="_blank" rel="noreferrer noopener">
+							consult the FAM
+						</Link>
+					</Box>
 					.
 				</P>
 			</Box>

--- a/src/components/LklCard.tsx
+++ b/src/components/LklCard.tsx
@@ -210,7 +210,6 @@ const LKLCard: React.FC<LKLCard> = ({ lklData }: LKLCard) => {
 	}
 	return (
 		<Box>
-			<Box backgroundColor={checkActive ? "success" : "silver"} h={3} w="full" />
 			<Card id="lklCard" maxWidth="full">
 				<Flex w="full" mt={{ base: "-8px", sm: "-16px" }}>
 					<Flex flexDir={{ base: "column", xl: "row" }} flexGrow={1}>
@@ -232,7 +231,6 @@ const LKLCard: React.FC<LKLCard> = ({ lklData }: LKLCard) => {
 						</Box>
 						<Dropdown
 							options={options}
-							borderedRows={true}
 							width="11rem"
 							label={`Additional actions for ${lklTitle}`}>
 							<Box as={MoreVertSharp} color="clickable" />

--- a/src/components/LklCard.tsx
+++ b/src/components/LklCard.tsx
@@ -95,7 +95,7 @@ const LKLCard: React.FC<LKLCard> = ({ lklData }: LKLCard) => {
 			},
 		},
 		{
-			label: checkActive ? "Deactivate" : "Activate",
+			label: (checkActive ? "Deactivate " : "Activate ") + "Location",
 			value: "Deactivate",
 			type: checkActive ? ("error" as const) : ("primary" as const),
 			onClick: () => {
@@ -233,7 +233,7 @@ const LKLCard: React.FC<LKLCard> = ({ lklData }: LKLCard) => {
 						<Dropdown
 							options={options}
 							borderedRows={true}
-							width="10rem"
+							width="11rem"
 							label={`Additional actions for ${lklTitle}`}>
 							<Box as={MoreVertSharp} color="clickable" />
 						</Dropdown>

--- a/src/components/LklCard.tsx
+++ b/src/components/LklCard.tsx
@@ -220,7 +220,7 @@ const LKLCard: React.FC<LKLCard> = ({ lklData }: LKLCard) => {
 						{/* location address */}
 						<Box mb={4}>
 							<FinePrint color="label">
-								U.S. Embassy in {city ? `${city},` : null}{countryCaseFixed}
+								U.S. Embassy in {city ? `${city}, ` : null}{countryCaseFixed}
 							</FinePrint>
 						</Box>
 					</Flex>

--- a/src/components/POCBox.tsx
+++ b/src/components/POCBox.tsx
@@ -176,19 +176,17 @@ const POCBox: React.FC<POCBoxProps> = (p: POCBoxProps) => {
 		// 6. For phone number, we might need an update to C1DS to allow Select component
 		//    to accept both dropdown and user input
 		<Box position="relative">
-			{ pocIndex !== 0 && 
-				<Box 
-					as={Close} 
-					m={8} 
-					right={0} 
-					position="absolute"
-					cursor="pointer"
-					color="text"
-					onClick={() => {
-						onRemove()
-					}}/>
-			}
-			
+			<Box 
+				as={Close} 
+				m={8} 
+				right={0} 
+				position="absolute"
+				cursor="pointer"
+				color="text"
+				onClick={() => {
+					onRemove()
+				}}/>
+		
 			<Grid
 				border="1px"
 				borderStyle="solid"

--- a/src/components/POCBox.tsx
+++ b/src/components/POCBox.tsx
@@ -67,7 +67,11 @@ const POCBox: React.FC<POCBoxProps> = (p: POCBoxProps) => {
 	}
 	
 	const filterOnTextChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-		e.target.value = e.target.value.replace(/^[^A-Za-z0-9]+/, "")
+		e.target.value = e.target.value.replace(/^[\s]+/, "")
+	}
+
+	const filterSpaceBeginning = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+		e.target.value = e.target.value.replace(/^[\s]+/, "")
 	}
 
 	// Name set onBlur behavior
@@ -255,6 +259,7 @@ const POCBox: React.FC<POCBoxProps> = (p: POCBoxProps) => {
 							isFirst={index === 0}
 							addable={addable}
 							onEmptyEmail={initialEmailList.length === 0}
+							filterOnTextChange={filterSpaceBeginning}
 							triggerAllFields={triggerAllFields}
 							onAdd={() => onAddEmail()}
 							onRemove={()=> {
@@ -276,7 +281,7 @@ const POCBox: React.FC<POCBoxProps> = (p: POCBoxProps) => {
 							isFirst={index === 0}
 							addable={addable}
 							onEmptyPhone={initialPhoneList.length === 0}
-							onPhoneNumberChange={filterOnTextChange}
+							filterOnTextChange={filterSpaceBeginning}
 							triggerAllFields={triggerAllFields}
 							onAdd={() => onAddPhone()}
 							onRemove={()=> {

--- a/src/components/POCEmail.tsx
+++ b/src/components/POCEmail.tsx
@@ -31,6 +31,7 @@ type POCEmailProps = {
     isFirst : boolean
     addable: boolean
     onEmptyEmail: boolean
+    filterOnTextChange : (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void
     triggerAllFields : () => void
     onAdd : () => void
     onRemove : () => void
@@ -38,7 +39,7 @@ type POCEmailProps = {
 
 // One set of Email address and type
 const POCEmail: React.FC<POCEmailProps> = ( p : POCEmailProps) => {
-    const { namePrefix, addable, isFirst, onEmptyEmail,
+    const { namePrefix, addable, isFirst, onEmptyEmail, filterOnTextChange,
             triggerAllFields, onAdd, onRemove } = p
     const { errors, formState, register } = useFormContext<LKLFormData>()
     const { dirtyFields } = formState
@@ -88,7 +89,7 @@ const POCEmail: React.FC<POCEmailProps> = ( p : POCEmailProps) => {
                         disabled={isDisabled}
                         validationState={errorsEmailDto?.emailAddress ? ValidationState.ERROR : undefined}
                         errorMessage={errorsEmailDto?.emailAddress?.message}
-                        onChange={filterSpaceBeginning}
+                        onChange={filterOnTextChange}
                         maxLength={67}
                         onBlur={() => {
                             triggerAllFields()
@@ -157,8 +158,3 @@ const POCEmail: React.FC<POCEmailProps> = ( p : POCEmailProps) => {
 }
 
 export default POCEmail
-
-
-const filterSpaceBeginning = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    e.target.value = e.target.value.replace(/^[\s]+/, "")
-}

--- a/src/components/POCPhone.tsx
+++ b/src/components/POCPhone.tsx
@@ -9,14 +9,14 @@ import { Phone, AddCircle, HighlightOff } from "@material-ui/icons"
 
 import phoneTypes_json from "../../content/phoneTypes.json"
 
-const PHONE_REGEX = /^([+]?\d{1,2}[.-\s]?)?(\(?\d{3}\)?[\s.-]?){2}\d{4}$/
+const PHONE_REGEX = /^([0-9\\\-()+.:# ]|(x|ext|extension))*$/
 
 type POCPhoneProps = {
     namePrefix: string
     isFirst : boolean
     addable: boolean
     onEmptyPhone: boolean
-    onPhoneNumberChange : (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void
+    filterOnTextChange : (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void
     triggerAllFields : () => void
     onAdd : () => void
     onRemove : () => void
@@ -25,7 +25,7 @@ type POCPhoneProps = {
 // One set of Phone number and type
 const POCPhone: React.FC<POCPhoneProps> = ( p : POCPhoneProps) => {
     const {namePrefix,  isFirst, addable, onEmptyPhone,
-            onPhoneNumberChange, triggerAllFields, onAdd, onRemove } = p
+            filterOnTextChange, triggerAllFields, onAdd, onRemove } = p
     const { errors, formState, register } = useFormContext<LKLFormData>()
     const { dirtyFields } = formState
     const isDisabled = false
@@ -73,7 +73,7 @@ const POCPhone: React.FC<POCPhoneProps> = ( p : POCPhoneProps) => {
                         disabled={isDisabled}
                         validationState={errorsPhoneList?.phoneNum ? ValidationState.ERROR : undefined}
                         errorMessage={errorsPhoneList?.phoneNum?.message}
-                        onChange={onPhoneNumberChange}
+                        onChange={filterOnTextChange}
                         maxLength={30}
                         onBlur={() => {
                             triggerAllFields()

--- a/src/components/PageSections/EventOverviewTab.tsx
+++ b/src/components/PageSections/EventOverviewTab.tsx
@@ -168,12 +168,14 @@ export const OverviewTab: React.FC<OverviewTabProps> = (p: OverviewTabProps) => 
 							*&nbsp;
 						</Text>
 						Which Consular Posts are impacted by this event?&nbsp; For a list of posts,{" "}
-						<Link
-							href="http://fam.a.state.sbu/fam/02FAM/02FAM0460.html#M463"
-							target="_blank"
-							rel="noreferrer noopener">
-							consult the FAM
-						</Link>
+						<Box as="span" textDecoration="underline">
+							<Link
+								href="http://fam.a.state.sbu/fam/02FAM/02FAM0460.html#M463"
+								target="_blank"
+								rel="noreferrer noopener">
+								consult the FAM
+							</Link>
+						</Box>
 						.
 					</P>
 				</Box>

--- a/src/components/Utility/lklFormHelpers.tsx
+++ b/src/components/Utility/lklFormHelpers.tsx
@@ -117,11 +117,12 @@ export const LlkFormData_To_LklDto = (lklFormData: LKLFormData, lklDto: LklDto |
 		pocList,
 	} = lklFormData
 
+	const pocListDefined = pocList ? pocList : []
 	const locationDescDefined = typeof locationDesc !== 'undefined' ? locationDesc : ''
 	const locationTypeDefined = typeof locationType !== 'undefined' ? locationType : ''
 
 	// Have to have name and either phone or email thus, without names = empty poc
-	const pocListDtoList = pocList
+	const pocListDtoList = pocListDefined
 		?.filter(poc => {
 			return poc.givenName !== "" || poc.surName !== ""
 		})

--- a/src/pages/addLocation.tsx
+++ b/src/pages/addLocation.tsx
@@ -80,6 +80,7 @@ const AddLocationPage: React.FC<AddLocationPageProps> = (p: AddLocationPageProps
 	const watchPost: string | undefined = useWatch({ control, name: "post" })
 	const countryRef = useRef<HTMLButtonElement>(null)
 	const postRef = useRef<HTMLButtonElement>(null)
+	const selectAllRef = useRef<HTMLInputElement>(null)
 	const breadcrumbs: LayoutProps["breadcrumbs"] = [{ label: "Event", onClick: onDataLossOpen }, { label: "Add Location" }]
 
 	const numOfPages = Math.ceil(locationList.length / locationsPerPage)
@@ -120,11 +121,17 @@ const AddLocationPage: React.FC<AddLocationPageProps> = (p: AddLocationPageProps
 	const submitSearchInputs = () => {
 		// @ts-ignore
 		// TODO: Update test data with email type code
-		let searchResults: LookupLklDto[] = watchCountry
-			? lookupLocations_json.filter(lookupLocation => {
-					return lookupLocation.lklAddressDto?.addressDto.countryCd === watchCountry
-			  })
-			: []
+		let searchResults: LookupLklDto[] = []
+		if(watchCountry){
+			searchResults = lookupLocations_json.filter(lookupLocation => {
+				return lookupLocation.lklAddressDto?.addressDto.countryCd === watchCountry
+			})
+			// Reset selection when country value is chagned
+			setSelectedLocationList([])
+			// Reset Select All
+			locListDispatch({ type: LocListActionTypes.TOGGLE, selected: false })
+			if(selectAllRef && selectAllRef.current ) selectAllRef.current.checked = false
+		}
 		if (watchPost) {
 			searchResults = searchResults.filter(lookupLocation => {
 				return lookupLocation.postCd === watchPost
@@ -355,6 +362,7 @@ const AddLocationPage: React.FC<AddLocationPageProps> = (p: AddLocationPageProps
 						<Grid gridColumn="1 / -1" gridTemplateColumns="repeat(2, 1fr)">
 							<Box ml={24} gridColumn="1 / 2" justifySelf="left">
 								<Checkbox
+									ref={selectAllRef}
 									id="selectAll"
 									aria-labelledby="selectAll"
 									value="Select all"


### PR DESCRIPTION
- [x] Impacted Posts: The “consult the FAM” text needs to be underlined.
- [x] Add Location: Previously selected locations remain if user submits a search for a new country.
- [x] New Location: POC Phone number input does not support international number
- [x] New Location: User cannot remove the first POC box
- [x] Last Known Location: “Deactivate” label should read as “Deactivate Location”.
- [x] Last Known Location: Remove top green & Grey border
- [x] Last Known Location: Remove the horizontal line in between “Edit Location” and “Deactivate”